### PR TITLE
privacy: stop leaking listen timestamps and raw email

### DIFF
--- a/src/components/mediaDisplay.jsx
+++ b/src/components/mediaDisplay.jsx
@@ -152,16 +152,6 @@ const TrackDisplay = ({ track, type }) => (
             )}
           </div>
           <div className="text-right">
-            {type === "recent" &&
-              (track.isNowPlaying ? (
-                <span className="rounded-full bg-emerald-600 px-2 py-1 text-xs text-white">
-                  Now Playing
-                </span>
-              ) : (
-                <span className="text-sm text-gray-500 dark:text-gray-400">
-                  {track.timestamp ? formatTimestamp(track.timestamp) : ""}
-                </span>
-              ))}
             {type === "top" && (
               <span className="text-sm text-gray-500 dark:text-gray-400">
                 {track.playcount} plays
@@ -186,17 +176,6 @@ TrackDisplay.propTypes = {
     playcount: PropTypes.number,
   }).isRequired,
   type: PropTypes.oneOf(["recent", "top"]).isRequired,
-}
-
-const formatTimestamp = timestamp => {
-  const date = new Date(timestamp)
-  const now = new Date()
-  const diff = now - date
-
-  if (diff < 60000) return "Just now"
-  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
-  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
-  return date.toLocaleDateString()
 }
 
 export { BookDisplay, WatchDisplay, TrackDisplay }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,11 +47,21 @@ import BaseLayout from "../layouts/BaseLayout.astro"
             Get in touch
           </p>
           <a
+            id="contact-email"
             class="text-xl break-words text-gray-900 underline decoration-red-700 md:mr-36 dark:text-white"
-            href="mailto:bren.reed@protonmail.com"
+            href="#"
           >
-            bren.reed@protonmail.com
+            Email me
           </a>
+          <script is:inline>
+            ;(function () {
+              const el = document.getElementById("contact-email")
+              if (!el) return
+              const addr = ["bren.reed", "protonmail.com"].join("@")
+              el.href = "mailto:" + addr
+              el.textContent = addr
+            })()
+          </script>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **`src/components/mediaDisplay.jsx`**: Removes the "Now Playing" badge and relative timestamps ("3m ago", "2h ago") from the recent tracks list on `/now`. These signals let anyone infer real-time presence. Artist/album still display; top tracks still show play counts. Deleted the now-unused `formatTimestamp` helper to keep the linter happy.
- **`src/pages/index.astro`**: Replaces the plaintext `mailto:bren.reed@protonmail.com` link with a client-side IIFE that assembles the address at runtime. The full email string is no longer present in page source or the built `index.html` (verified with `grep`).

## Test plan

- [ ] `/now` → Recent Tracks section shows tracks with artist/album only — no "ago" text, no "Now Playing" badge
- [ ] Homepage "Get in touch" → link text reads the email address and resolves correctly on click
- [ ] `grep -r "bren.reed@protonmail.com" dist/` returns nothing for `index.html`
- [ ] `npm run build` passes clean

**Note:** The client-side assembly defeats naive scrapers but not a JS-executing crawler. A Netlify Forms contact form (no address on page at all) would be the fully bulletproof version — flagging as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)