### PR TITLE
Interactive honeymoon itinerary tracker (/honeymoon)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,14 @@ export default defineConfig({
   site: "https://brendanreed.net",
   output: "static",
   adapter: netlify(),
-  integrations: [react(), mdx(), sitemap()],
+  integrations: [
+    react(),
+    mdx(),
+    sitemap({
+      // Keep the private honeymoon tracker out of the sitemap.
+      filter: page => !page.includes("/honeymoon"),
+    }),
+  ],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/components/HoneymoonTracker.jsx
+++ b/src/components/HoneymoonTracker.jsx
@@ -1,0 +1,383 @@
+import { useEffect, useMemo, useState } from "react"
+import { meta, stops, transits, checklist, budget } from "../data/honeymoon"
+
+const STORAGE_KEY = "honeymoon-tracker-v1"
+
+const mapsUrl = q =>
+  `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(q)}`
+
+// Transits render after these stops, in order.
+const TRANSIT_ORDER = ["london", "mykonos", "paros", "milos", "nice"]
+const transitAfter = stopId => {
+  const i = TRANSIT_ORDER.indexOf(stopId)
+  return i === -1 ? null : transits[i]
+}
+
+const usd = n =>
+  n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  })
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) return JSON.parse(raw)
+  } catch {
+    /* ignore */
+  }
+  return {}
+}
+
+export default function HoneymoonTracker() {
+  const [checks, setChecks] = useState({})
+  const [notes, setNotes] = useState({})
+  const [packing, setPacking] = useState({})
+  const [openNotes, setOpenNotes] = useState({})
+  const [tab, setTab] = useState("itinerary")
+  const [hydrated, setHydrated] = useState(false)
+
+  // Hydrate from localStorage after mount (client:only — no SSR mismatch).
+  useEffect(() => {
+    const s = loadState()
+    if (s.checks) setChecks(s.checks)
+    if (s.notes) setNotes(s.notes)
+    if (s.packing) setPacking(s.packing)
+    setHydrated(true)
+  }, [])
+
+  // Persist on change.
+  useEffect(() => {
+    if (!hydrated) return
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ checks, notes, packing }),
+      )
+    } catch {
+      /* ignore */
+    }
+  }, [checks, notes, packing, hydrated])
+
+  // Scroll-reveal for destination sections.
+  useEffect(() => {
+    if (tab !== "itinerary") return
+    const els = Array.from(document.querySelectorAll(".destination"))
+    if (!("IntersectionObserver" in window)) {
+      els.forEach(el => el.classList.add("visible"))
+      return
+    }
+    const obs = new IntersectionObserver(
+      entries =>
+        entries.forEach(e => {
+          if (e.isIntersecting) e.target.classList.add("visible")
+        }),
+      { threshold: 0.08 },
+    )
+    els.forEach(el => obs.observe(el))
+    return () => obs.disconnect()
+  }, [tab, hydrated])
+
+  const allDays = useMemo(() => stops.flatMap(s => s.days), [])
+  const doneCount = allDays.filter(d => checks[d.id]).length
+  const pct = allDays.length
+    ? Math.round((doneCount / allDays.length) * 100)
+    : 0
+
+  const toggleCheck = id => setChecks(c => ({ ...c, [id]: !c[id] }))
+  const togglePack = id => setPacking(p => ({ ...p, [id]: !p[id] }))
+  const setNote = (id, v) => setNotes(n => ({ ...n, [id]: v }))
+  const toggleOpen = id => setOpenNotes(o => ({ ...o, [id]: !o[id] }))
+
+  const bookedTotal = budget
+    .filter(b => b.booked)
+    .reduce((s, b) => s + b.amount, 0)
+  const grandTotal = budget.reduce((s, b) => s + b.amount, 0)
+
+  const checklistCats = ["To Book", "Before We Go", "Packing"]
+
+  return (
+    <>
+      {/* HERO */}
+      <section className="hero">
+        <p className="hero-label">{meta.travelers}</p>
+        <h1 className="hero-title">
+          {meta.title.lead}
+          <br />
+          <em>{meta.title.em}</em>
+        </h1>
+        <p className="hero-sub">{meta.subtitle}</p>
+        <div className="hero-route">
+          {meta.route.map((r, i) => (
+            <span key={r.label} style={{ display: "contents" }}>
+              <span
+                className={`hero-route-stop${r.highlight ? " highlight" : ""}`}
+              >
+                {r.label}
+              </span>
+              {i < meta.route.length - 1 && <span className="hero-route-dot" />}
+            </span>
+          ))}
+        </div>
+        <div className="scroll-hint">
+          <div className="scroll-line" />
+          <span>Scroll to explore</span>
+        </div>
+      </section>
+
+      {/* OVERVIEW STRIP */}
+      <div className="overview">
+        {meta.stats.map(s => (
+          <div className="overview-stat" key={s.label}>
+            <div className="num">{s.num}</div>
+            <div className="label">{s.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* STICKY CONTROL BAR */}
+      <div className="ctrlbar">
+        <div className="ctrlbar-inner">
+          <div className="tabs">
+            <button
+              className={`tab${tab === "itinerary" ? " active" : ""}`}
+              onClick={() => setTab("itinerary")}
+            >
+              Itinerary
+            </button>
+            <button
+              className={`tab${tab === "checklist" ? " active" : ""}`}
+              onClick={() => setTab("checklist")}
+            >
+              To-Do
+            </button>
+            <button
+              className={`tab${tab === "budget" ? " active" : ""}`}
+              onClick={() => setTab("budget")}
+            >
+              Budget
+            </button>
+          </div>
+          <div className="progress">
+            <div className="progress-track">
+              <div className="progress-fill" style={{ width: `${pct}%` }} />
+            </div>
+            <span className="progress-text">
+              {doneCount}/{allDays.length} days
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="container">
+        {/* ITINERARY */}
+        {tab === "itinerary" &&
+          stops.map(stop => {
+            const t = transitAfter(stop.id)
+            return (
+              <div key={stop.id}>
+                <section className="destination" id={stop.id}>
+                  <div className="dest-header">
+                    <div className="dest-number">{stop.number}</div>
+                    <div className="dest-meta">
+                      <div className="dest-tag">{stop.tag}</div>
+                      <h2 className="dest-name">
+                        {stop.name.lead}
+                        <em>{stop.name.em}</em>
+                        {stop.name.trail}
+                      </h2>
+                      <p className="dest-dates">{stop.dates}</p>
+                    </div>
+                  </div>
+
+                  <div className="days">
+                    {stop.days.map(day => {
+                      const done = !!checks[day.id]
+                      const open = !!openNotes[day.id]
+                      const hasNote = !!(notes[day.id] || "").trim()
+                      return (
+                        <div
+                          className={`day-card${done ? " done" : ""}`}
+                          key={day.id}
+                        >
+                          <div className="day-label">
+                            <strong>{day.dateLabel}</strong>
+                            {day.part}
+                          </div>
+                          <div className="day-content">
+                            <button
+                              className={`day-check${done ? " checked" : ""}`}
+                              onClick={() => toggleCheck(day.id)}
+                              aria-pressed={done}
+                              title={done ? "Mark not done" : "Mark done"}
+                            >
+                              <span className="day-check-box">
+                                {done ? "✓" : ""}
+                              </span>
+                              <span className="day-title">{day.title}</span>
+                            </button>
+                            <p className="day-desc">{day.desc}</p>
+
+                            {(day.tags?.length || day.spots?.length) && (
+                              <div className="day-highlights">
+                                {day.tags?.map((tg, i) => (
+                                  <span
+                                    className={`tag tag-${tg.kind}`}
+                                    key={`tag-${i}`}
+                                  >
+                                    {tg.label}
+                                  </span>
+                                ))}
+                                {day.spots?.map((sp, i) => (
+                                  <a
+                                    className="tag tag-map"
+                                    key={`spot-${i}`}
+                                    href={sp.url || mapsUrl(sp.mapsQuery)}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title={sp.note || `Open ${sp.name} in Maps`}
+                                  >
+                                    📍 {sp.name}
+                                  </a>
+                                ))}
+                              </div>
+                            )}
+
+                            <div className="note-row">
+                              <button
+                                className="note-toggle"
+                                onClick={() => toggleOpen(day.id)}
+                              >
+                                {open
+                                  ? "− Hide note"
+                                  : hasNote
+                                    ? "✎ Edit note"
+                                    : "＋ Add note"}
+                              </button>
+                              {hasNote && !open && (
+                                <span className="note-preview">
+                                  {notes[day.id]}
+                                </span>
+                              )}
+                            </div>
+                            {open && (
+                              <textarea
+                                className="note-input"
+                                placeholder="Reservations, confirmation #s, ideas…"
+                                value={notes[day.id] || ""}
+                                onChange={e => setNote(day.id, e.target.value)}
+                              />
+                            )}
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </section>
+
+                {t && (
+                  <div className="transit">
+                    <span className="transit-icon">{t.icon}</span>
+                    <span className="transit-text">
+                      <strong>{t.lead}</strong> · {t.text}
+                    </span>
+                    <span
+                      className={`transit-badge${t.booked ? " booked" : ""}`}
+                    >
+                      {t.badge || (t.booked ? "✓ Booked" : "To book")}
+                    </span>
+                  </div>
+                )}
+
+                {stop.id !== stops[stops.length - 1].id && (
+                  <div className="section-divider" />
+                )}
+              </div>
+            )
+          })}
+
+        {/* CHECKLIST */}
+        {tab === "checklist" &&
+          checklistCats.map(cat => {
+            const items = checklist.filter(c => c.category === cat)
+            if (!items.length) return null
+            const done = items.filter(i => packing[i.id]).length
+            return (
+              <section className="list-section" key={cat}>
+                <h3 className="list-head">
+                  {cat}
+                  <span className="list-count">
+                    {done}/{items.length}
+                  </span>
+                </h3>
+                <ul className="checklist">
+                  {items.map(i => (
+                    <li key={i.id}>
+                      <label
+                        className={`check-row${packing[i.id] ? " checked" : ""}`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={!!packing[i.id]}
+                          onChange={() => togglePack(i.id)}
+                        />
+                        <span className="check-box">
+                          {packing[i.id] ? "✓" : ""}
+                        </span>
+                        <span className="check-label">{i.label}</span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )
+          })}
+
+        {/* BUDGET */}
+        {tab === "budget" && (
+          <section className="list-section">
+            <h3 className="list-head">
+              Budget
+              <span className="list-count">estimates</span>
+            </h3>
+            <ul className="budget">
+              {budget.map(b => (
+                <li className="budget-row" key={b.id}>
+                  <span className="budget-label">{b.label}</span>
+                  <span className="budget-amt">
+                    {b.amount > 0
+                      ? `${b.est ? "~" : ""}${usd(b.amount)}`
+                      : "TBD"}
+                  </span>
+                  <span className={`budget-badge${b.booked ? " booked" : ""}`}>
+                    {b.booked ? "Booked" : "Open"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <div className="budget-totals">
+              <div>
+                <span className="budget-total-label">Booked so far</span>
+                <span className="budget-total-num">~{usd(bookedTotal)}</span>
+              </div>
+              <div>
+                <span className="budget-total-label">Running total</span>
+                <span className="budget-total-num">~{usd(grandTotal)}</span>
+              </div>
+            </div>
+            <p className="budget-note">
+              Estimates from planning notes. Flights are per-person where noted
+              — edit <code>src/data/honeymoon.ts</code> to refine.
+            </p>
+          </section>
+        )}
+      </div>
+
+      <footer>
+        <div className="footer-title">{meta.dateRange}</div>
+        <p>{meta.route.map(r => r.label).join(" · ")}</p>
+      </footer>
+    </>
+  )
+}

--- a/src/components/HoneymoonTracker.jsx
+++ b/src/components/HoneymoonTracker.jsx
@@ -7,7 +7,7 @@ const mapsUrl = q =>
   `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(q)}`
 
 // Transits render after these stops, in order.
-const TRANSIT_ORDER = ["london", "mykonos", "paros", "milos", "nice"]
+const TRANSIT_ORDER = ["london", "mykonos", "paros", "milos", "nice", "nyc"]
 const transitAfter = stopId => {
   const i = TRANSIT_ORDER.indexOf(stopId)
   return i === -1 ? null : transits[i]

--- a/src/components/HoneymoonTracker.jsx
+++ b/src/components/HoneymoonTracker.jsx
@@ -6,11 +6,34 @@ const STORAGE_KEY = "honeymoon-tracker-v1"
 const mapsUrl = q =>
   `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(q)}`
 
+// Multi-stop route for a day: directions through all spots (origin = current
+// location), single spot falls back to a plain search.
+const dayRouteUrl = spots => {
+  if (!spots || !spots.length) return null
+  if (spots.length === 1) return mapsUrl(spots[0].mapsQuery)
+  const pts = spots.map(s => encodeURIComponent(s.mapsQuery))
+  const destination = pts[pts.length - 1]
+  const waypoints = pts.slice(0, -1).join("|")
+  return `https://www.google.com/maps/dir/?api=1&destination=${destination}&waypoints=${waypoints}`
+}
+
 // Transits render after these stops, in order.
 const TRANSIT_ORDER = ["london", "mykonos", "paros", "milos", "nice", "nyc"]
 const transitAfter = stopId => {
   const i = TRANSIT_ORDER.indexOf(stopId)
   return i === -1 ? null : transits[i]
+}
+
+// Hero route label → stop id to scroll to.
+const ROUTE_TO_STOP = {
+  Chicago: "departure",
+  London: "london",
+  Mykonos: "mykonos",
+  Paros: "paros",
+  Milos: "milos",
+  Nice: "nice",
+  "New York": "nyc",
+  Home: "nyc",
 }
 
 const usd = n =>
@@ -19,6 +42,18 @@ const usd = n =>
     currency: "USD",
     maximumFractionDigits: 0,
   })
+
+const parseISO = s => {
+  const [y, m, d] = s.split("-").map(Number)
+  return new Date(y, m - 1, d)
+}
+const todayISO = () => {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+    d.getDate(),
+  ).padStart(2, "0")}`
+}
+const dayDiff = (a, b) => Math.round((parseISO(b) - parseISO(a)) / 86400000)
 
 function loadState() {
   try {
@@ -30,12 +65,20 @@ function loadState() {
   return {}
 }
 
+const scrollToId = id => {
+  const el = document.getElementById(id)
+  if (el) el.scrollIntoView({ behavior: "smooth", block: "start" })
+}
+
 export default function HoneymoonTracker() {
   const [checks, setChecks] = useState({})
   const [notes, setNotes] = useState({})
+  const [conf, setConf] = useState({})
+  const [links, setLinks] = useState({})
   const [packing, setPacking] = useState({})
-  const [openNotes, setOpenNotes] = useState({})
+  const [openDetails, setOpenDetails] = useState({})
   const [tab, setTab] = useState("itinerary")
+  const [view, setView] = useState("story") // story | agenda
   const [hydrated, setHydrated] = useState(false)
 
   // Hydrate from localStorage after mount (client:only — no SSR mismatch).
@@ -43,6 +86,8 @@ export default function HoneymoonTracker() {
     const s = loadState()
     if (s.checks) setChecks(s.checks)
     if (s.notes) setNotes(s.notes)
+    if (s.conf) setConf(s.conf)
+    if (s.links) setLinks(s.links)
     if (s.packing) setPacking(s.packing)
     setHydrated(true)
   }, [])
@@ -53,16 +98,16 @@ export default function HoneymoonTracker() {
     try {
       localStorage.setItem(
         STORAGE_KEY,
-        JSON.stringify({ checks, notes, packing }),
+        JSON.stringify({ checks, notes, conf, links, packing }),
       )
     } catch {
       /* ignore */
     }
-  }, [checks, notes, packing, hydrated])
+  }, [checks, notes, conf, links, packing, hydrated])
 
-  // Scroll-reveal for destination sections.
+  // Scroll-reveal for the Story view's destination sections.
   useEffect(() => {
-    if (tab !== "itinerary") return
+    if (tab !== "itinerary" || view !== "story") return
     const els = Array.from(document.querySelectorAll(".destination"))
     if (!("IntersectionObserver" in window)) {
       els.forEach(el => el.classList.add("visible"))
@@ -77,7 +122,7 @@ export default function HoneymoonTracker() {
     )
     els.forEach(el => obs.observe(el))
     return () => obs.disconnect()
-  }, [tab, hydrated])
+  }, [tab, view, hydrated])
 
   const allDays = useMemo(() => stops.flatMap(s => s.days), [])
   const doneCount = allDays.filter(d => checks[d.id]).length
@@ -85,17 +130,119 @@ export default function HoneymoonTracker() {
     ? Math.round((doneCount / allDays.length) * 100)
     : 0
 
+  // ── "Today" awareness ──────────────────────────────────────────────────────
+  const tripStart = allDays[0].date
+  const tripEnd = allDays[allDays.length - 1].date
+  const status = useMemo(() => {
+    const t = todayISO()
+    if (dayDiff(t, tripStart) > 0)
+      return { phase: "before", days: dayDiff(t, tripStart) }
+    if (dayDiff(tripEnd, t) >= 0)
+      return { phase: "during", day: dayDiff(tripStart, t) + 1 }
+    return { phase: "after" }
+  }, [tripStart, tripEnd])
+
+  const today = todayISO()
+  // current day = last day card matching today (where the day ends up)
+  const currentDay = useMemo(() => {
+    const matches = allDays.filter(d => d.date === today)
+    return matches.length ? matches[matches.length - 1] : null
+  }, [allDays, today])
+  const currentStopId = useMemo(() => {
+    if (!currentDay) return null
+    const s = stops.find(st => st.days.some(d => d.id === currentDay.id))
+    return s ? s.id : null
+  }, [currentDay])
+
+  const totalDays = dayDiff(tripStart, tripEnd) + 1
+
   const toggleCheck = id => setChecks(c => ({ ...c, [id]: !c[id] }))
   const togglePack = id => setPacking(p => ({ ...p, [id]: !p[id] }))
   const setNote = (id, v) => setNotes(n => ({ ...n, [id]: v }))
-  const toggleOpen = id => setOpenNotes(o => ({ ...o, [id]: !o[id] }))
+  const setConfVal = (id, v) => setConf(c => ({ ...c, [id]: v }))
+  const setLinkVal = (id, v) => setLinks(l => ({ ...l, [id]: v }))
+  const toggleOpen = id => setOpenDetails(o => ({ ...o, [id]: !o[id] }))
 
   const bookedTotal = budget
     .filter(b => b.booked)
     .reduce((s, b) => s + b.amount, 0)
   const grandTotal = budget.reduce((s, b) => s + b.amount, 0)
-
   const checklistCats = ["To Book", "Before We Go", "Packing"]
+
+  const goToday = () => currentDay && scrollToId(`day-${currentDay.id}`)
+
+  // ── Shared per-day detail panel (notes / confirmation / link) ───────────────
+  const renderDetails = day => {
+    const open = !!openDetails[day.id]
+    const hasData = !!(
+      (notes[day.id] || "").trim() ||
+      (conf[day.id] || "").trim() ||
+      (links[day.id] || "").trim()
+    )
+    return (
+      <div className="details">
+        <div className="details-actions">
+          <button className="mini-btn" onClick={() => toggleOpen(day.id)}>
+            {open ? "− Hide details" : hasData ? "✎ Details" : "＋ Add details"}
+          </button>
+          {day.spots && day.spots.length > 0 && (
+            <a
+              className="mini-btn"
+              href={dayRouteUrl(day.spots)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              🗺 Day route in Maps
+            </a>
+          )}
+          {links[day.id] && (
+            <a
+              className="mini-btn link-live"
+              href={links[day.id]}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ↗ Booking
+            </a>
+          )}
+          {conf[day.id] && !open && (
+            <span className="conf-chip">#{conf[day.id]}</span>
+          )}
+        </div>
+        {open && (
+          <div className="details-fields">
+            <label className="field">
+              <span className="field-label">Confirmation #</span>
+              <input
+                className="field-input"
+                value={conf[day.id] || ""}
+                onChange={e => setConfVal(day.id, e.target.value)}
+                placeholder="e.g. ABC123"
+              />
+            </label>
+            <label className="field">
+              <span className="field-label">Booking link</span>
+              <input
+                className="field-input"
+                value={links[day.id] || ""}
+                onChange={e => setLinkVal(day.id, e.target.value)}
+                placeholder="https://…"
+              />
+            </label>
+            <label className="field field-wide">
+              <span className="field-label">Notes</span>
+              <textarea
+                className="field-input note-input"
+                value={notes[day.id] || ""}
+                onChange={e => setNote(day.id, e.target.value)}
+                placeholder="Reservations, ideas, reminders…"
+              />
+            </label>
+          </div>
+        )}
+      </div>
+    )
+  }
 
   return (
     <>
@@ -110,12 +257,13 @@ export default function HoneymoonTracker() {
         <p className="hero-sub">{meta.subtitle}</p>
         <div className="hero-route">
           {meta.route.map((r, i) => (
-            <span key={r.label} style={{ display: "contents" }}>
-              <span
+            <span key={r.label + i} style={{ display: "contents" }}>
+              <button
                 className={`hero-route-stop${r.highlight ? " highlight" : ""}`}
+                onClick={() => scrollToId(ROUTE_TO_STOP[r.label] || "")}
               >
                 {r.label}
-              </span>
+              </button>
               {i < meta.route.length - 1 && <span className="hero-route-dot" />}
             </span>
           ))}
@@ -134,6 +282,30 @@ export default function HoneymoonTracker() {
             <div className="label">{s.label}</div>
           </div>
         ))}
+      </div>
+
+      {/* STATUS / TODAY BANNER */}
+      <div className={`status status-${status.phase}`}>
+        {status.phase === "before" && (
+          <span>
+            ✈ <strong>{status.days}</strong>{" "}
+            {status.days === 1 ? "day" : "days"} until departure
+          </span>
+        )}
+        {status.phase === "during" && (
+          <>
+            <span>
+              💛 <strong>Day {status.day}</strong> of {totalDays}
+              {currentDay ? ` · ${currentDay.dateLabel}` : ""}
+            </span>
+            {currentDay && (
+              <button className="status-btn" onClick={goToday}>
+                Jump to today ↓
+              </button>
+            )}
+          </>
+        )}
+        {status.phase === "after" && <span>💛 Welcome home</span>}
       </div>
 
       {/* STICKY CONTROL BAR */}
@@ -168,16 +340,50 @@ export default function HoneymoonTracker() {
             </span>
           </div>
         </div>
+
+        {tab === "itinerary" && (
+          <div className="subbar">
+            <div className="viewtoggle">
+              <button
+                className={`vt${view === "story" ? " active" : ""}`}
+                onClick={() => setView("story")}
+              >
+                Story
+              </button>
+              <button
+                className={`vt${view === "agenda" ? " active" : ""}`}
+                onClick={() => setView("agenda")}
+              >
+                Agenda
+              </button>
+            </div>
+            <div className="stopnav">
+              {stops.map(s => (
+                <button
+                  key={s.id}
+                  className={`stopchip${currentStopId === s.id ? " current" : ""}`}
+                  onClick={() => scrollToId(s.id)}
+                >
+                  {s.name.em}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="container">
-        {/* ITINERARY */}
+        {/* ITINERARY — STORY VIEW */}
         {tab === "itinerary" &&
+          view === "story" &&
           stops.map(stop => {
             const t = transitAfter(stop.id)
             return (
               <div key={stop.id}>
-                <section className="destination" id={stop.id}>
+                <section
+                  className={`destination${currentStopId === stop.id ? " current-stop" : ""}`}
+                  id={stop.id}
+                >
                   <div className="dest-header">
                     <div className="dest-number">{stop.number}</div>
                     <div className="dest-meta">
@@ -194,23 +400,25 @@ export default function HoneymoonTracker() {
                   <div className="days">
                     {stop.days.map(day => {
                       const done = !!checks[day.id]
-                      const open = !!openNotes[day.id]
-                      const hasNote = !!(notes[day.id] || "").trim()
+                      const isToday = day.date === today
                       return (
                         <div
-                          className={`day-card${done ? " done" : ""}`}
+                          className={`day-card${done ? " done" : ""}${isToday ? " today" : ""}`}
+                          id={`day-${day.id}`}
                           key={day.id}
                         >
                           <div className="day-label">
                             <strong>{day.dateLabel}</strong>
                             {day.part}
+                            {isToday && (
+                              <span className="today-pill">Today</span>
+                            )}
                           </div>
                           <div className="day-content">
                             <button
                               className={`day-check${done ? " checked" : ""}`}
                               onClick={() => toggleCheck(day.id)}
                               aria-pressed={done}
-                              title={done ? "Mark not done" : "Mark done"}
                             >
                               <span className="day-check-box">
                                 {done ? "✓" : ""}
@@ -236,7 +444,6 @@ export default function HoneymoonTracker() {
                                     href={sp.url || mapsUrl(sp.mapsQuery)}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    title={sp.note || `Open ${sp.name} in Maps`}
                                   >
                                     📍 {sp.name}
                                   </a>
@@ -244,31 +451,7 @@ export default function HoneymoonTracker() {
                               </div>
                             )}
 
-                            <div className="note-row">
-                              <button
-                                className="note-toggle"
-                                onClick={() => toggleOpen(day.id)}
-                              >
-                                {open
-                                  ? "− Hide note"
-                                  : hasNote
-                                    ? "✎ Edit note"
-                                    : "＋ Add note"}
-                              </button>
-                              {hasNote && !open && (
-                                <span className="note-preview">
-                                  {notes[day.id]}
-                                </span>
-                              )}
-                            </div>
-                            {open && (
-                              <textarea
-                                className="note-input"
-                                placeholder="Reservations, confirmation #s, ideas…"
-                                value={notes[day.id] || ""}
-                                onChange={e => setNote(day.id, e.target.value)}
-                              />
-                            )}
+                            {renderDetails(day)}
                           </div>
                         </div>
                       )
@@ -292,6 +475,74 @@ export default function HoneymoonTracker() {
 
                 {stop.id !== stops[stops.length - 1].id && (
                   <div className="section-divider" />
+                )}
+              </div>
+            )
+          })}
+
+        {/* ITINERARY — AGENDA VIEW */}
+        {tab === "itinerary" &&
+          view === "agenda" &&
+          stops.map(stop => {
+            const t = transitAfter(stop.id)
+            return (
+              <div key={stop.id} className="agenda-stop" id={stop.id}>
+                <div
+                  className={`agenda-head${currentStopId === stop.id ? " current" : ""}`}
+                >
+                  <span className="agenda-stop-name">
+                    {stop.name.lead}
+                    {stop.name.em}
+                    {stop.name.trail}
+                  </span>
+                  <span className="agenda-stop-dates">{stop.dates}</span>
+                </div>
+                {stop.days.map(day => {
+                  const done = !!checks[day.id]
+                  const isToday = day.date === today
+                  return (
+                    <div
+                      className={`agenda-row${done ? " done" : ""}${isToday ? " today" : ""}`}
+                      id={`day-${day.id}`}
+                      key={day.id}
+                    >
+                      <button
+                        className={`agenda-check${done ? " checked" : ""}`}
+                        onClick={() => toggleCheck(day.id)}
+                        aria-pressed={done}
+                      >
+                        {done ? "✓" : ""}
+                      </button>
+                      <div className="agenda-when">
+                        <span className="agenda-date">{day.dateLabel}</span>
+                        <span className="agenda-part">{day.part}</span>
+                      </div>
+                      <div className="agenda-main">
+                        <div className="agenda-title">
+                          {day.title}
+                          {isToday && <span className="today-pill">Today</span>}
+                        </div>
+                        {day.spots && day.spots.length > 0 && (
+                          <a
+                            className="agenda-maps"
+                            href={dayRouteUrl(day.spots)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            🗺 {day.spots.length} spots
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  )
+                })}
+                {t && (
+                  <div className="agenda-transit">
+                    <span>{t.icon}</span>
+                    <span>
+                      <strong>{t.lead}</strong> · {t.text}
+                    </span>
+                  </div>
                 )}
               </div>
             )
@@ -367,8 +618,8 @@ export default function HoneymoonTracker() {
               </div>
             </div>
             <p className="budget-note">
-              Estimates from planning notes. Flights are per-person where noted
-              — edit <code>src/data/honeymoon.ts</code> to refine.
+              Estimates from planning notes. Edit{" "}
+              <code>src/data/honeymoon.ts</code> to refine.
             </p>
           </section>
         )}

--- a/src/components/HoneymoonTracker.jsx
+++ b/src/components/HoneymoonTracker.jsx
@@ -77,6 +77,7 @@ export default function HoneymoonTracker() {
   const [links, setLinks] = useState({})
   const [packing, setPacking] = useState({})
   const [openDetails, setOpenDetails] = useState({})
+  const [openTimeline, setOpenTimeline] = useState({})
   const [tab, setTab] = useState("itinerary")
   const [view, setView] = useState("story") // story | agenda
   const [hydrated, setHydrated] = useState(false)
@@ -162,6 +163,7 @@ export default function HoneymoonTracker() {
   const setConfVal = (id, v) => setConf(c => ({ ...c, [id]: v }))
   const setLinkVal = (id, v) => setLinks(l => ({ ...l, [id]: v }))
   const toggleOpen = id => setOpenDetails(o => ({ ...o, [id]: !o[id] }))
+  const toggleTimeline = id => setOpenTimeline(o => ({ ...o, [id]: !o[id] }))
 
   const bookedTotal = budget
     .filter(b => b.booked)
@@ -170,6 +172,72 @@ export default function HoneymoonTracker() {
   const checklistCats = ["To Book", "Before We Go", "Packing"]
 
   const goToday = () => currentDay && scrollToId(`day-${currentDay.id}`)
+
+  // ── Hour-by-hour timeline (collapsible, Story view) ─────────────────────────
+  const BOOKING_LABEL = {
+    booked: "✓ Booked",
+    "to-book": "To book",
+    "walk-in": "Walk-in",
+  }
+  const renderTimeline = day => {
+    if (!day.timeline || !day.timeline.length) return null
+    const open = !!openTimeline[day.id]
+    return (
+      <div className="timeline-wrap">
+        <button
+          className="mini-btn timeline-toggle"
+          onClick={() => toggleTimeline(day.id)}
+        >
+          {open ? "− Hide hour-by-hour" : "⌚ Hour-by-hour"} ·{" "}
+          {day.timeline.length} stops
+        </button>
+        {open && (
+          <ol className="timeline">
+            {day.timeline.map((e, i) => (
+              <li className={`tl-row tl-${e.kind}`} key={`tl-${i}`}>
+                <span className="tl-time">{e.time}</span>
+                <span className="tl-dot" />
+                <div className="tl-body">
+                  <div className="tl-title">
+                    {e.mapsQuery ? (
+                      <a
+                        className="tl-link"
+                        href={mapsUrl(e.mapsQuery)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {e.title}
+                      </a>
+                    ) : (
+                      e.title
+                    )}
+                  </div>
+                  {e.detail && <div className="tl-detail">{e.detail}</div>}
+                  {(e.travelTime || e.duration || e.booking) && (
+                    <div className="tl-meta">
+                      {e.travelTime && (
+                        <span className="tl-chip tl-chip-travel">
+                          → {e.travelTime}
+                        </span>
+                      )}
+                      {e.duration && (
+                        <span className="tl-chip">{e.duration}</span>
+                      )}
+                      {e.booking && (
+                        <span className={`tl-chip tl-chip-${e.booking}`}>
+                          {BOOKING_LABEL[e.booking]}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    )
+  }
 
   // ── Shared per-day detail panel (notes / confirmation / link) ───────────────
   const renderDetails = day => {
@@ -451,6 +519,7 @@ export default function HoneymoonTracker() {
                               </div>
                             )}
 
+                            {renderTimeline(day)}
                             {renderDetails(day)}
                           </div>
                         </div>

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -94,7 +94,7 @@ export interface TripMeta {
 export const meta: TripMeta = {
   title: { lead: "Our", em: "Honeymoon" },
   travelers: "Brendan & Scott · August–September 2026",
-  dateRange: "August 23 – September 13, 2026",
+  dateRange: "August 23 – September 8, 2026",
   subtitle: "London · Greek Islands · Côte d'Azur · New York",
   route: [
     { label: "Chicago", highlight: true },
@@ -107,12 +107,12 @@ export const meta: TripMeta = {
     { label: "Home", highlight: true },
   ],
   stats: [
-    { num: "21", label: "Days Away" },
+    { num: "16", label: "Nights Away" },
     { num: "7", label: "Destinations" },
     { num: "6", label: "Flights" },
     { num: "3", label: "Islands" },
     { num: "Aug 23", label: "Departure" },
-    { num: "Sep 13", label: "Home" },
+    { num: "Sep 8", label: "Home" },
   ],
 }
 
@@ -493,13 +493,12 @@ export const stops: Stop[] = [
       },
       {
         id: "nyc-sep8",
-        dateLabel: "Sep 8+",
+        dateLabel: "Sep 8",
         part: "Home",
-        title: "Back to Chicago · Recovery",
-        desc: "Fly home to O'Hare on Delta (DL 2240), then recovery and a spa day through Sep 13. The honeymoon ends, the marriage continues.",
+        title: "Back to Chicago",
+        desc: "Fly home to O'Hare on Delta (DL 2240). The honeymoon ends, the marriage continues. A recovery day or two to land back in real life.",
         tags: [
           { kind: "transport", label: "NYC → ORD · DL 2240" },
-          { kind: "activity", label: "Spa / Recovery Day" },
           { kind: "transport", label: "Home ❤" },
         ],
       },

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -130,11 +130,11 @@ export const stops: Stop[] = [
         dateLabel: "Aug 23",
         part: "Evening",
         title: "Depart O'Hare for London Heathrow",
-        desc: "An Uber from Wrigleyville to ORD, then the overnight flight begins. British Airways First Class — fully flat beds, champagne, the works. Wake up over the Atlantic with England below.",
+        desc: "An Uber from Wrigleyville to O'Hare for the 9:15pm departure, then the overnight flight begins. British Airways First Class — fully flat beds, champagne, the works. Wake up over the Atlantic with England below.",
         tags: [
           { kind: "transport", label: "British Airways 296 · First" },
           { kind: "booked", label: "✓ Booked" },
-          { kind: "transport", label: "ORD → LHR" },
+          { kind: "transport", label: "ORD → LHR · 9:15pm" },
         ],
         spots: [
           {
@@ -155,39 +155,54 @@ export const stops: Stop[] = [
       {
         id: "lon-aug24",
         dateLabel: "Aug 24",
-        part: "Arrival",
-        title: "Land at Heathrow · Settle In",
-        desc: "Morning arrival into Terminal 5. Transfer to the Bankside Hotel (Autograph Collection) on the South Bank, rest, and ease into London time. An afternoon walk — the Thames, Southbank, wherever the mood takes you.",
+        part: "Day 1 · Arrival",
+        title: "Land 11:15am · Bankside & Borough Market",
+        desc: "Land at Heathrow around 11:15am and drop bags at the Bankside Hotel (Autograph Collection) on the South Bank. Lunch at Borough Market, then Shakespeare's Globe and the Tate Modern next door, and a walk up through Regent's Park (maybe La Fromagerie). Martinis at the Hawksmoor bar in King's Cross, then dinner at Dishoom King's Cross.",
         tags: [
-          { kind: "transport", label: "LHR Terminal 5" },
+          { kind: "transport", label: "Land LHR ~11:15am" },
           { kind: "stay", label: "Bankside Hotel" },
+          { kind: "activity", label: "Shakespeare's Globe" },
+          { kind: "food", label: "Borough Market Lunch" },
+          { kind: "food", label: "Dishoom King's Cross" },
         ],
         spots: [
           {
             name: "Bankside Hotel, Autograph Collection",
             mapsQuery: "Bankside Hotel Autograph Collection London",
           },
+          { name: "Borough Market", mapsQuery: "Borough Market, London" },
           {
-            name: "The Wallace Collection",
-            mapsQuery: "The Wallace Collection, London",
+            name: "Shakespeare's Globe",
+            mapsQuery: "Shakespeare's Globe, London",
           },
           { name: "Tate Modern", mapsQuery: "Tate Modern, London" },
           { name: "Regent's Park", mapsQuery: "Regent's Park, London" },
+          {
+            name: "La Fromagerie",
+            mapsQuery: "La Fromagerie Marylebone, London",
+          },
+          {
+            name: "Hawksmoor Bar, King's Cross",
+            mapsQuery: "Hawksmoor King's Cross, London",
+          },
+          {
+            name: "Dishoom King's Cross",
+            mapsQuery: "Dishoom King's Cross, London",
+          },
         ],
       },
       {
         id: "lon-aug25",
         dateLabel: "Aug 25",
-        part: "Full Day",
-        title: "A Day in the City",
-        desc: "One full day to soak up London — the shops, the markets, a West End show in the evening. Book theatre ahead; the good productions sell out weeks out.",
+        part: "Day 2",
+        title: "Shops · The Wallace Collection · Tea",
+        desc: "A day for the shops: Liberty of London and Fortnum & Mason, then the Wallace Collection. Afternoon tea at Dean Street Townhouse to close out London.",
         tags: [
-          { kind: "activity", label: "West End Theatre" },
-          { kind: "food", label: "Dinner at Dean St Townhouse" },
-          { kind: "transport", label: "Tube / Bus" },
+          { kind: "activity", label: "Liberty + Fortnum & Mason" },
+          { kind: "activity", label: "The Wallace Collection" },
+          { kind: "food", label: "Tea at Dean St Townhouse" },
         ],
         spots: [
-          { name: "Borough Market", mapsQuery: "Borough Market, London" },
           {
             name: "Liberty London",
             mapsQuery: "Liberty London, Great Marlborough St",
@@ -196,7 +211,10 @@ export const stops: Stop[] = [
             name: "Fortnum & Mason",
             mapsQuery: "Fortnum & Mason, Piccadilly, London",
           },
-          { name: "Savile Row", mapsQuery: "Savile Row, London" },
+          {
+            name: "The Wallace Collection",
+            mapsQuery: "The Wallace Collection, London",
+          },
           {
             name: "Dean Street Townhouse",
             mapsQuery: "Dean Street Townhouse, Soho, London",
@@ -215,9 +233,9 @@ export const stops: Stop[] = [
       {
         id: "myk-aug26",
         dateLabel: "Aug 26",
-        part: "Arrival",
+        part: "Day 1 · Arrival",
         title: "Touch Down on the Cyclades",
-        desc: "Direct from Heathrow into Mykonos (BA 668) — the only Greek island with a direct Heathrow connection. Transfer to Rocabella Mykonos, find the water, and let Greece begin.",
+        desc: "Depart Heathrow 10:55am on BA 668 and land in Mykonos around 4:50pm — the only Greek island with a direct Heathrow connection. Drop bags at Rocabella Mykonos, find the water, and let Greece begin.",
         tags: [
           { kind: "stay", label: "Rocabella Mykonos" },
           { kind: "food", label: "Dinner in Mykonos Town" },
@@ -256,7 +274,7 @@ export const stops: Stop[] = [
         dateLabel: "Aug 28",
         part: "Morning",
         title: "Early Breakfast · 9:40am Ferry to Paros",
-        desc: "One last breakfast in Mykonos, then the 9:40am high-speed ferry south — roughly 40 minutes across brilliant blue water.",
+        desc: "One last breakfast in Mykonos, then the 9:40am high-speed ferry south — about 45 minutes, arriving Paros around 10:25am.",
         tags: [{ kind: "transport", label: "Mykonos → Paros · 9:40am ferry" }],
       },
     ],
@@ -301,7 +319,7 @@ export const stops: Stop[] = [
         dateLabel: "Aug 30",
         part: "Morning",
         title: "Breakfast · 10:10am Ferry to Milos",
-        desc: "Morning coffee in Paros, then the 10:10am ferry southwest to Milos — about 1 hour 45 on the fastest service.",
+        desc: "Morning coffee in Paros, then the 10:10am ferry southwest to Milos, arriving around noon.",
         tags: [{ kind: "transport", label: "Paros → Milos · 10:10am ferry" }],
       },
     ],
@@ -352,7 +370,7 @@ export const stops: Stop[] = [
         dateLabel: "Sep 1",
         part: "Morning",
         title: "Early Flight · Athens Layover · On to Nice",
-        desc: "Early Sky Express flight from Milos (GQ 419, 8:55am) to Athens — about 40 minutes. A layover at Athens, then the early-afternoon Aegean flight to Nice (A3 690, 1:35pm). Arrive on the Riviera in time for dinner.",
+        desc: "Sky Express GQ 419 departs Milos 8:55am and lands in Athens around 9:35am. A layover at Athens airport, then Aegean A3 690 departs 1:35pm and lands in Nice around 3:10pm. On the Riviera in time for dinner.",
         tags: [
           {
             kind: "transport",
@@ -375,7 +393,7 @@ export const stops: Stop[] = [
         dateLabel: "Sep 1",
         part: "Arrival",
         title: "Bienvenue sur la Riviera",
-        desc: "Arrive early afternoon from Athens and check in at Le Méridien Nice, right on the Promenade des Anglais. Vieux-Nice and the best rosé in the world are waiting. A light dinner and an early night — the Riviera rewards those who sleep.",
+        desc: "Land around 3:10pm from Athens and check in at Le Méridien Nice, right on the Promenade des Anglais. Vieux-Nice and the best rosé in the world are waiting. A light dinner and an early night — the Riviera rewards those who sleep.",
         tags: [
           { kind: "stay", label: "Le Méridien Nice" },
           { kind: "food", label: "Dinner in Vieux-Nice" },
@@ -441,7 +459,7 @@ export const stops: Stop[] = [
         dateLabel: "Sep 4",
         part: "Arrival",
         title: "Into New York",
-        desc: "La Compagnie into Newark (B0 200, 12:25pm dep) — all-business class, so you arrive refreshed. Transfer to the Moxy NYC Chelsea. New York hits differently after two weeks in Europe.",
+        desc: "La Compagnie B0 200 departs Nice 12:25pm and lands at Newark around 3:45pm — all-business class, so you arrive refreshed. Transfer to the Moxy NYC Chelsea. New York hits differently after two weeks in Europe.",
         tags: [
           { kind: "stay", label: "Moxy NYC Chelsea" },
           { kind: "food", label: "Welcome Back to America Dinner" },
@@ -496,9 +514,9 @@ export const stops: Stop[] = [
         dateLabel: "Sep 8",
         part: "Home",
         title: "Back to Chicago",
-        desc: "Fly home to O'Hare on Delta (DL 2240). The honeymoon ends, the marriage continues. A recovery day or two to land back in real life.",
+        desc: "Delta DL 2240 departs New York 11:30am and lands at O'Hare around 1:15pm. The honeymoon ends, the marriage continues.",
         tags: [
-          { kind: "transport", label: "NYC → ORD · DL 2240" },
+          { kind: "transport", label: "NYC → ORD · DL 2240 · 11:30am" },
           { kind: "transport", label: "Home ❤" },
         ],
       },
@@ -511,43 +529,43 @@ export const transits: Transit[] = [
   {
     id: "t-lon-myk",
     icon: "✈",
-    lead: "Aug 26 morning",
-    text: "British Airways 668 direct · LHR T5 → Mykonos JMK · ~4 hours",
+    lead: "Aug 26 · 10:55am",
+    text: "British Airways 668 direct · LHR T5 → Mykonos JMK · lands ~4:50pm",
     booked: true,
   },
   {
     id: "t-myk-par",
     icon: "⛴",
     lead: "Aug 28 · 9:40am",
-    text: "High-speed ferry · Mykonos → Paros · ~40 minutes",
+    text: "High-speed ferry · Mykonos → Paros · arrives ~10:25am",
     booked: true,
   },
   {
     id: "t-par-mil",
     icon: "⛴",
     lead: "Aug 30 · 10:10am",
-    text: "High-speed ferry · Paros → Milos · ~1 hour 45 minutes",
+    text: "High-speed ferry · Paros → Milos · arrives ~12:00pm",
     booked: true,
   },
   {
     id: "t-mil-nce",
     icon: "✈",
     lead: "Sep 1",
-    text: "Sky Express GQ 419: MLO 8:55am → ATH · then Aegean A3 690: ATH 1:35pm → NCE",
+    text: "Sky Express GQ 419: MLO 8:55am → ATH 9:35am · then Aegean A3 690: ATH 1:35pm → NCE ~3:10pm",
     booked: true,
   },
   {
     id: "t-nce-nyc",
     icon: "✈",
     lead: "Sep 4 · 12:25pm",
-    text: "La Compagnie B0 200 all-business · NCE → EWR · Direct",
+    text: "La Compagnie B0 200 all-business · NCE → EWR · lands ~3:45pm",
     booked: true,
   },
   {
     id: "t-nyc-ord",
     icon: "✈",
-    lead: "Sep 8",
-    text: "Delta DL 2240 · New York → Chicago O'Hare",
+    lead: "Sep 8 · 11:30am",
+    text: "Delta DL 2240 · New York → Chicago O'Hare · lands ~1:15pm",
     booked: true,
   },
 ]
@@ -555,13 +573,18 @@ export const transits: Transit[] = [
 // ── CHECKLIST (To Book / Packing / Before We Go) ───────────────────────────────
 export const checklist: ChecklistItem[] = [
   {
-    id: "cl-westend",
-    label: "Book West End show (London)",
+    id: "cl-globe",
+    label: "Book Shakespeare's Globe tickets (London Day 1)",
+    category: "To Book",
+  },
+  {
+    id: "cl-dishoom",
+    label: "Reserve Hawksmoor bar + Dishoom King's Cross (Day 1)",
     category: "To Book",
   },
   {
     id: "cl-deanst",
-    label: "Reserve Dean Street Townhouse dinner",
+    label: "Reserve Dean Street Townhouse tea (Day 2)",
     category: "To Book",
   },
   {

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -1,0 +1,651 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// HONEYMOON ITINERARY — SINGLE SOURCE OF TRUTH
+//
+// This is the only file you need to edit to update the tracker at /honeymoon.
+// Everything (hero, stops, day cards, transit rows, maps links, packing list,
+// budget) renders from the data below.
+//
+// QUICK EDITING GUIDE
+//   • Dates/times/flight numbers: edit the relevant `transits` row or `day`.
+//   • Mark something booked: set `booked: true` on a transit or budget item.
+//   • Add a place: add to a day's `spots` array — `mapsQuery` becomes a
+//     Google/Apple Maps link automatically.
+//   • Add a packing/to-book item: add to `checklist` below.
+//   • Budget: edit `budget` — totals compute automatically; `est: true` marks
+//     a number as a rough estimate (shows a "~").
+//
+// VALUES MARKED `tbd: true` OR `booked: false` are placeholders Brendan still
+// needs to confirm. Real booked values from notes are filled where known.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type TagKind = "transport" | "stay" | "activity" | "food" | "booked"
+
+export interface Spot {
+  name: string
+  /** Free-text query opened in Google/Apple Maps. */
+  mapsQuery: string
+  /** Optional external link (official site / booking). */
+  url?: string
+  note?: string
+}
+
+export interface Tag {
+  kind: TagKind
+  label: string
+}
+
+export interface Day {
+  /** Stable id — used to persist check-off + notes in localStorage. Don't reuse. */
+  id: string
+  dateLabel: string // e.g. "Aug 24"
+  part: string // e.g. "Arrival" / "Full Day" / "Morning"
+  title: string
+  desc: string
+  tags?: Tag[]
+  spots?: Spot[]
+}
+
+export interface Stop {
+  id: string
+  number: string // "01"
+  tag: string // "Stop One"
+  /** Name rendered with the part in <em> italicised/accent. */
+  name: { lead?: string; em: string; trail?: string }
+  dates: string
+  days: Day[]
+}
+
+export interface Transit {
+  id: string
+  icon: string // ✈ / ⛴
+  /** Bolded lead fragment, then the rest of the line. */
+  lead: string
+  text: string
+  booked: boolean
+  /** Override the auto badge text if you like. */
+  badge?: string
+}
+
+export interface ChecklistItem {
+  id: string
+  label: string
+  category: "To Book" | "Packing" | "Before We Go"
+  done?: boolean // default-checked seed; live state is stored in localStorage
+}
+
+export interface BudgetItem {
+  id: string
+  label: string
+  amount: number // USD
+  booked: boolean
+  est?: boolean // show "~" for rough estimates
+}
+
+export interface TripMeta {
+  title: { lead: string; em: string }
+  travelers: string
+  dateRange: string
+  subtitle: string
+  route: { label: string; highlight?: boolean }[]
+  stats: { num: string; label: string }[]
+}
+
+// ── META ─────────────────────────────────────────────────────────────────────
+export const meta: TripMeta = {
+  title: { lead: "Our", em: "Honeymoon" },
+  travelers: "Brendan & Scott · August–September 2026",
+  dateRange: "August 23 – September 13, 2026",
+  subtitle: "London · Greek Islands · Côte d'Azur · New York",
+  route: [
+    { label: "Chicago", highlight: true },
+    { label: "London" },
+    { label: "Mykonos" },
+    { label: "Paros" },
+    { label: "Milos" },
+    { label: "Nice" },
+    { label: "New York" },
+    { label: "Home", highlight: true },
+  ],
+  stats: [
+    { num: "21", label: "Days Away" },
+    { num: "7", label: "Destinations" },
+    { num: "6", label: "Flights" },
+    { num: "3", label: "Islands" },
+    { num: "Aug 23", label: "Departure" },
+    { num: "Sep 13", label: "Home" },
+  ],
+}
+
+// ── STOPS ──────────────────────────────────────────────────────────────────--
+export const stops: Stop[] = [
+  {
+    id: "departure",
+    number: "01",
+    tag: "Departure",
+    name: { lead: "Chicago ", em: "to", trail: " London" },
+    dates: "Sunday, August 23",
+    days: [
+      {
+        id: "dep-aug23",
+        dateLabel: "Aug 23",
+        part: "Evening",
+        title: "Depart O'Hare for London Heathrow",
+        desc: "An Uber from Wrigleyville to ORD, then the overnight flight begins. British Airways First Class — fully flat beds, champagne, the works. Wake up over the Atlantic with England below.",
+        tags: [
+          { kind: "transport", label: "British Airways 296 · First" },
+          { kind: "booked", label: "✓ Booked" },
+          { kind: "transport", label: "ORD → LHR" },
+        ],
+        spots: [
+          {
+            name: "Chicago O'Hare (ORD)",
+            mapsQuery: "O'Hare International Airport",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "london",
+    number: "02",
+    tag: "Stop One",
+    name: { em: "London", trail: ", England" },
+    dates: "August 24–25 · 2 nights",
+    days: [
+      {
+        id: "lon-aug24",
+        dateLabel: "Aug 24",
+        part: "Arrival",
+        title: "Land at Heathrow · Settle In",
+        desc: "Morning arrival into Terminal 5. Transfer to the hotel, rest, and ease into London time. An afternoon walk — the Thames, Southbank, wherever the mood takes you.",
+        tags: [
+          { kind: "transport", label: "LHR Terminal 5" },
+          { kind: "stay", label: "Hotel Check-in" },
+        ],
+        spots: [
+          {
+            name: "The Wallace Collection",
+            mapsQuery: "The Wallace Collection, London",
+          },
+          { name: "Tate Modern", mapsQuery: "Tate Modern, London" },
+          { name: "Regent's Park", mapsQuery: "Regent's Park, London" },
+        ],
+      },
+      {
+        id: "lon-aug25",
+        dateLabel: "Aug 25",
+        part: "Full Day",
+        title: "A Day in the City",
+        desc: "One full day to soak up London — the shops, the markets, a West End show in the evening. Book theatre ahead; the good productions sell out weeks out.",
+        tags: [
+          { kind: "activity", label: "West End Theatre" },
+          { kind: "food", label: "Dinner at Dean St Townhouse" },
+          { kind: "transport", label: "Tube / Bus" },
+        ],
+        spots: [
+          { name: "Borough Market", mapsQuery: "Borough Market, London" },
+          {
+            name: "Liberty London",
+            mapsQuery: "Liberty London, Great Marlborough St",
+          },
+          {
+            name: "Fortnum & Mason",
+            mapsQuery: "Fortnum & Mason, Piccadilly, London",
+          },
+          { name: "Savile Row", mapsQuery: "Savile Row, London" },
+          {
+            name: "Dean Street Townhouse",
+            mapsQuery: "Dean Street Townhouse, Soho, London",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "mykonos",
+    number: "03",
+    tag: "Island One",
+    name: { em: "Mykonos", trail: ", Greece" },
+    dates: "August 26–27 · 2 nights",
+    days: [
+      {
+        id: "myk-aug26",
+        dateLabel: "Aug 26",
+        part: "Arrival",
+        title: "Touch Down on the Cyclades",
+        desc: "Direct from Heathrow into Mykonos — the only Greek island with a direct Heathrow connection. Transfer to the hotel, find the water, and let Greece begin.",
+        tags: [
+          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "food", label: "Dinner in Mykonos Town" },
+        ],
+        spots: [
+          { name: "Mykonos Windmills", mapsQuery: "Windmills of Mykonos" },
+          { name: "Little Venice", mapsQuery: "Little Venice, Mykonos" },
+        ],
+      },
+      {
+        id: "myk-aug27",
+        dateLabel: "Aug 27",
+        part: "Full Day",
+        title: "Elia Beach · Mykonos Town",
+        desc: "Mykonos does beaches and nightlife better than almost anywhere. Elia or Super Paradise for the day, then Mykonos Town at sunset. Consider a beach club day with a minimum spend — Scorpios and Jackie O' are the iconic options.",
+        tags: [
+          { kind: "activity", label: "Beach Club" },
+          { kind: "activity", label: "Town + Windmills" },
+          { kind: "food", label: "Drinks & Nightlife" },
+        ],
+        spots: [
+          { name: "Elia Beach", mapsQuery: "Elia Beach, Mykonos" },
+          { name: "Scorpios", mapsQuery: "Scorpios Mykonos" },
+          {
+            name: "Jackie O' Beach",
+            mapsQuery: "Jackie O' Beach Club Mykonos",
+          },
+        ],
+      },
+      {
+        id: "myk-aug28",
+        dateLabel: "Aug 28",
+        part: "Morning",
+        title: "Breakfast · Ferry to Paros",
+        desc: "One last breakfast in Mykonos, then the high-speed ferry south — roughly 40 minutes across brilliant blue water.",
+        tags: [{ kind: "transport", label: "Mykonos → Paros · ~40 min ferry" }],
+      },
+    ],
+  },
+  {
+    id: "paros",
+    number: "04",
+    tag: "Island Two",
+    name: { em: "Paros", trail: ", Greece" },
+    dates: "August 28–29 · 2 nights",
+    days: [
+      {
+        id: "par-aug28",
+        dateLabel: "Aug 28",
+        part: "Arrival",
+        title: "Welcome to a Quieter Island",
+        desc: "Paros is the antidote to Mykonos — still gorgeous, still Cycladic, but calmer. The harbor at Naoussa is one of the prettiest in Greece. Arrive, find your hotel, breathe.",
+        tags: [
+          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "food", label: "Dinner in Naoussa" },
+        ],
+        spots: [{ name: "Naoussa", mapsQuery: "Naoussa, Paros, Greece" }],
+      },
+      {
+        id: "par-aug29",
+        dateLabel: "Aug 29",
+        part: "Full Day",
+        title: "Naoussa · Day Trip to Antiparos",
+        desc: "The 30-minute boat to tiny Antiparos is one of the best day trips in the Cyclades — near-empty beaches and a relaxed village (the sauna-guy recommendation). A sailboat ride around the islands fits the afternoon perfectly.",
+        tags: [
+          { kind: "activity", label: "Antiparos Day Trip" },
+          { kind: "activity", label: "Sailboat Ride" },
+          { kind: "food", label: "Seafood Dinner" },
+        ],
+        spots: [{ name: "Antiparos", mapsQuery: "Antiparos, Greece" }],
+      },
+      {
+        id: "par-aug30",
+        dateLabel: "Aug 30",
+        part: "Morning",
+        title: "Breakfast · Ferry to Milos",
+        desc: "Morning coffee in Paros, then the ferry southwest to Milos — about 1 hour 45 on the fastest service.",
+        tags: [{ kind: "transport", label: "Paros → Milos · ~1h 45m ferry" }],
+      },
+    ],
+  },
+  {
+    id: "milos",
+    number: "05",
+    tag: "Island Three",
+    name: { em: "Milos", trail: ", Greece" },
+    dates: "August 30 – September 1 · 2 nights",
+    days: [
+      {
+        id: "mil-aug30",
+        dateLabel: "Aug 30",
+        part: "Arrival",
+        title: "The Volcanic Island",
+        desc: "Milos is arguably the most dramatic landscape in the Cyclades — shaped by ancient volcanism into lunar-white cliffs, turquoise coves, and sulfuric hot springs. Check in and explore.",
+        tags: [
+          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "activity", label: "Rent Car or Scooter" },
+        ],
+      },
+      {
+        id: "mil-aug31",
+        dateLabel: "Aug 31",
+        part: "Full Day",
+        title: "Sarakiniko · Kleftiko · Firopotamos",
+        desc: "The moon-white pumice landscape of Sarakiniko is unmissable. Kleftiko sea caves are best by boat. In the evening, a winery tour — Milos produces excellent local wine.",
+        tags: [
+          { kind: "activity", label: "Sarakiniko Beach" },
+          { kind: "activity", label: "Kleftiko Sea Caves (boat)" },
+          { kind: "activity", label: "Winery Tour" },
+        ],
+        spots: [
+          { name: "Sarakiniko Beach", mapsQuery: "Sarakiniko Beach, Milos" },
+          { name: "Kleftiko", mapsQuery: "Kleftiko, Milos" },
+          { name: "Firopotamos", mapsQuery: "Firopotamos, Milos" },
+        ],
+      },
+      {
+        id: "mil-sep1",
+        dateLabel: "Sep 1",
+        part: "Morning",
+        title: "Early Flight · Athens Layover · On to Nice",
+        desc: "Early Olympic Air flight from Milos (MLO) to Athens — about 40 minutes. A long but manageable layover at Athens before the afternoon Aegean flight to Nice. Arrive on the Riviera in time for dinner.",
+        tags: [
+          { kind: "transport", label: "MLO → ATH · Olympic Air · ~40 min" },
+          { kind: "transport", label: "ATH → NCE · Aegean A3 690" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "nice",
+    number: "06",
+    tag: "Stop Two",
+    name: { em: "Nice", trail: ", Côte d'Azur" },
+    dates: "September 1–3 · 3 nights",
+    days: [
+      {
+        id: "nce-sep1",
+        dateLabel: "Sep 1",
+        part: "Arrival",
+        title: "Bienvenue sur la Riviera",
+        desc: "Arrive early evening from Athens. The Promenade des Anglais, Vieux-Nice, and the best rosé in the world are waiting. A light dinner and an early night — the Riviera rewards those who sleep.",
+        tags: [
+          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "food", label: "Dinner in Vieux-Nice" },
+        ],
+        spots: [
+          {
+            name: "Promenade des Anglais",
+            mapsQuery: "Promenade des Anglais, Nice",
+          },
+          {
+            name: "Vieux-Nice (Old Town)",
+            mapsQuery: "Vieux Nice, Nice, France",
+          },
+        ],
+      },
+      {
+        id: "nce-sep2",
+        dateLabel: "Sep 2",
+        part: "Full Day",
+        title: "Nice · Èze · The Corniche",
+        desc: "A perfect Riviera day: the Old Town market in the morning, then the Grande Corniche to the perched village of Èze for lunch and vertigo-inducing views. Spa in the afternoon if the mood strikes.",
+        tags: [
+          { kind: "activity", label: "Cours Saleya Market" },
+          { kind: "activity", label: "Èze Village" },
+          { kind: "activity", label: "Spa Day" },
+          { kind: "food", label: "Fancy Dinner" },
+        ],
+        spots: [
+          { name: "Cours Saleya Market", mapsQuery: "Cours Saleya, Nice" },
+          { name: "Èze Village", mapsQuery: "Èze, France" },
+        ],
+      },
+      {
+        id: "nce-sep3",
+        dateLabel: "Sep 3",
+        part: "Full Day",
+        title: "Day Trip: Monaco",
+        desc: "A 20-minute train ride to the most glamorous microstate in Europe. The Casino de Monte-Carlo, a harbor full of superyachts, a long lunch overlooking it all. Back to Nice for a final Riviera dinner.",
+        tags: [
+          { kind: "activity", label: "Monaco Day Trip" },
+          { kind: "activity", label: "Casino de Monte-Carlo" },
+          { kind: "food", label: "Final Nice Dinner" },
+        ],
+        spots: [
+          {
+            name: "Casino de Monte-Carlo",
+            mapsQuery: "Casino de Monte-Carlo, Monaco",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "nyc",
+    number: "07",
+    tag: "Grand Finale",
+    name: { em: "New York", trail: " City" },
+    dates: "September 4–7 · US Open",
+    days: [
+      {
+        id: "nyc-sep4",
+        dateLabel: "Sep 4",
+        part: "Arrival",
+        title: "Into New York",
+        desc: "La Compagnie into Newark — all-business class, so you arrive refreshed. Transfer to the hotel in the city. New York hits differently after two weeks in Europe.",
+        tags: [
+          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "food", label: "Welcome Back to America Dinner" },
+        ],
+      },
+      {
+        id: "nyc-sep5",
+        dateLabel: "Sep 5",
+        part: "Match Day",
+        title: "US Open — Arthur Ashe Stadium",
+        desc: "The US Open runs Aug 31 – Sep 13; early September is the sweet spot — the best players still in it, the roar of the crowd, the best tennis in the world at Flushing Meadows.",
+        tags: [
+          { kind: "activity", label: "US Open · Arthur Ashe" },
+          { kind: "food", label: "Post-match Dinner" },
+        ],
+        spots: [
+          {
+            name: "Arthur Ashe Stadium",
+            mapsQuery: "Arthur Ashe Stadium, Flushing Meadows",
+          },
+        ],
+      },
+      {
+        id: "nyc-sep6",
+        dateLabel: "Sep 6",
+        part: "Full Day",
+        title: "The City · Final Dinner",
+        desc: "A last full day in New York — whatever you want it to be: a museum, a walk across the Brooklyn Bridge, shopping, a long brunch. End with a dinner worth remembering.",
+        tags: [
+          { kind: "activity", label: "Explore NYC" },
+          { kind: "food", label: "Farewell Dinner — make it special" },
+        ],
+        spots: [
+          { name: "Brooklyn Bridge", mapsQuery: "Brooklyn Bridge, New York" },
+        ],
+      },
+      {
+        id: "nyc-sep7",
+        dateLabel: "Sep 7+",
+        part: "Home",
+        title: "Back to Chicago · Recovery",
+        desc: "Fly home to O'Hare and Wrigleyville (return date still being finalized — 9/9 or 9/10), with recovery and a spa day through Sep 13. The honeymoon ends, the marriage continues.",
+        tags: [
+          { kind: "transport", label: "NYC → ORD" },
+          { kind: "activity", label: "Spa / Recovery Day" },
+          { kind: "transport", label: "Home ❤" },
+        ],
+      },
+    ],
+  },
+]
+
+// ── TRANSITS (rendered between stops, in order) ────────────────────────────────
+export const transits: Transit[] = [
+  {
+    id: "t-lon-myk",
+    icon: "✈",
+    lead: "Aug 26 morning",
+    text: "British Airways 668 direct · LHR T5 → Mykonos JMK · ~4 hours",
+    booked: true,
+  },
+  {
+    id: "t-myk-par",
+    icon: "⛴",
+    lead: "Aug 28",
+    text: "High-speed ferry · Mykonos → Paros · SeaJets / Golden Star · ~40 min",
+    booked: false,
+    badge: "Confirm time",
+  },
+  {
+    id: "t-par-mil",
+    icon: "⛴",
+    lead: "Aug 30",
+    text: "High-speed ferry · Paros → Milos · ~1 hour 45 minutes",
+    booked: false,
+    badge: "Confirm time",
+  },
+  {
+    id: "t-mil-nce",
+    icon: "✈",
+    lead: "Sep 1",
+    text: "Olympic Air: MLO → ATH · then Aegean A3 690: ATH 16:25 → NCE 18:05",
+    booked: true,
+  },
+  {
+    id: "t-nce-nyc",
+    icon: "✈",
+    lead: "Sep 4",
+    text: "La Compagnie B0 200 all-business · NCE → EWR · Direct",
+    booked: true,
+  },
+]
+
+// ── CHECKLIST (To Book / Packing / Before We Go) ───────────────────────────────
+export const checklist: ChecklistItem[] = [
+  {
+    id: "cl-ferry1",
+    label: "Book Mykonos → Paros ferry (FerryHopper)",
+    category: "To Book",
+  },
+  {
+    id: "cl-ferry2",
+    label: "Book Paros → Milos ferry (FerryHopper)",
+    category: "To Book",
+  },
+  {
+    id: "cl-hotels",
+    label: "Confirm all 6 hotels (London, 3 islands, Nice, NYC)",
+    category: "To Book",
+  },
+  {
+    id: "cl-nycflight",
+    label: "Book return NYC → ORD flight (9/9 or 9/10)",
+    category: "To Book",
+  },
+  {
+    id: "cl-usopen",
+    label: "Buy US Open tickets (Arthur Ashe)",
+    category: "To Book",
+  },
+  {
+    id: "cl-westend",
+    label: "Book West End show (London)",
+    category: "To Book",
+  },
+  {
+    id: "cl-deanst",
+    label: "Reserve Dean Street Townhouse dinner",
+    category: "To Book",
+  },
+  {
+    id: "cl-beachclub",
+    label: "Reserve Mykonos beach club (Scorpios / Jackie O')",
+    category: "To Book",
+  },
+  {
+    id: "cl-milosboat",
+    label: "Book Kleftiko boat tour (Milos)",
+    category: "To Book",
+  },
+  {
+    id: "cl-passport",
+    label: "Check passports valid 6+ months past travel",
+    category: "Before We Go",
+  },
+  { id: "cl-insurance", label: "Travel insurance", category: "Before We Go" },
+  {
+    id: "cl-euro",
+    label: "Get euros / set up cards for travel",
+    category: "Before We Go",
+  },
+  {
+    id: "cl-esim",
+    label: "EU + UK eSIM / data plan",
+    category: "Before We Go",
+  },
+  { id: "cl-adapters", label: "UK + EU plug adapters", category: "Packing" },
+  {
+    id: "cl-suncare",
+    label: "Sunscreen, swimwear, beach gear",
+    category: "Packing",
+  },
+  {
+    id: "cl-formal",
+    label: "Formal wear (theatre, casino, fancy dinners)",
+    category: "Packing",
+  },
+]
+
+// ── BUDGET (USD; est: true shows "~") ──────────────────────────────────────────
+export const budget: BudgetItem[] = [
+  {
+    id: "b-ba296",
+    label: "Flight · BA 296 ORD→LHR (First)",
+    amount: 7600,
+    booked: true,
+    est: true,
+  },
+  {
+    id: "b-ba668",
+    label: "Flight · BA 668 LHR→Mykonos",
+    amount: 275,
+    booked: true,
+    est: true,
+  },
+  {
+    id: "b-a3690",
+    label: "Flight · Olympic + Aegean A3 690 →Nice",
+    amount: 450,
+    booked: true,
+    est: true,
+  },
+  {
+    id: "b-lacomp",
+    label: "Flight · La Compagnie B0 200 NCE→EWR",
+    amount: 4510,
+    booked: true,
+    est: true,
+  },
+  {
+    id: "b-nycord",
+    label: "Flight · NYC→ORD return",
+    amount: 120,
+    booked: false,
+    est: true,
+  },
+  {
+    id: "b-ferries",
+    label: "Greek island ferries (×2)",
+    amount: 0,
+    booked: false,
+    est: true,
+  },
+  {
+    id: "b-hotels",
+    label: "Hotels (6 stops)",
+    amount: 0,
+    booked: false,
+    est: true,
+  },
+  {
+    id: "b-usopen",
+    label: "US Open tickets",
+    amount: 0,
+    booked: false,
+    est: true,
+  },
+]

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -14,8 +14,8 @@
 //   • Budget: edit `budget` — totals compute automatically; `est: true` marks
 //     a number as a rough estimate (shows a "~").
 //
-// VALUES MARKED `tbd: true` OR `booked: false` are placeholders Brendan still
-// needs to confirm. Real booked values from notes are filled where known.
+// Flights, hotels, and ferries are all booked (real values below). Remaining
+// `booked: false` items are reservations/tickets still to sort.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type TagKind = "transport" | "stay" | "activity" | "food" | "booked"
@@ -157,12 +157,16 @@ export const stops: Stop[] = [
         dateLabel: "Aug 24",
         part: "Arrival",
         title: "Land at Heathrow · Settle In",
-        desc: "Morning arrival into Terminal 5. Transfer to the hotel, rest, and ease into London time. An afternoon walk — the Thames, Southbank, wherever the mood takes you.",
+        desc: "Morning arrival into Terminal 5. Transfer to the Bankside Hotel (Autograph Collection) on the South Bank, rest, and ease into London time. An afternoon walk — the Thames, Southbank, wherever the mood takes you.",
         tags: [
           { kind: "transport", label: "LHR Terminal 5" },
-          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "stay", label: "Bankside Hotel" },
         ],
         spots: [
+          {
+            name: "Bankside Hotel, Autograph Collection",
+            mapsQuery: "Bankside Hotel Autograph Collection London",
+          },
           {
             name: "The Wallace Collection",
             mapsQuery: "The Wallace Collection, London",
@@ -206,19 +210,23 @@ export const stops: Stop[] = [
     number: "03",
     tag: "Island One",
     name: { em: "Mykonos", trail: ", Greece" },
-    dates: "August 26–27 · 2 nights",
+    dates: "August 26–28 · 2 nights",
     days: [
       {
         id: "myk-aug26",
         dateLabel: "Aug 26",
         part: "Arrival",
         title: "Touch Down on the Cyclades",
-        desc: "Direct from Heathrow into Mykonos — the only Greek island with a direct Heathrow connection. Transfer to the hotel, find the water, and let Greece begin.",
+        desc: "Direct from Heathrow into Mykonos (BA 668) — the only Greek island with a direct Heathrow connection. Transfer to Rocabella Mykonos, find the water, and let Greece begin.",
         tags: [
-          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "stay", label: "Rocabella Mykonos" },
           { kind: "food", label: "Dinner in Mykonos Town" },
         ],
         spots: [
+          {
+            name: "Rocabella Mykonos",
+            mapsQuery: "Rocabella Mykonos Hotel",
+          },
           { name: "Mykonos Windmills", mapsQuery: "Windmills of Mykonos" },
           { name: "Little Venice", mapsQuery: "Little Venice, Mykonos" },
         ],
@@ -247,9 +255,9 @@ export const stops: Stop[] = [
         id: "myk-aug28",
         dateLabel: "Aug 28",
         part: "Morning",
-        title: "Breakfast · Ferry to Paros",
-        desc: "One last breakfast in Mykonos, then the high-speed ferry south — roughly 40 minutes across brilliant blue water.",
-        tags: [{ kind: "transport", label: "Mykonos → Paros · ~40 min ferry" }],
+        title: "Early Breakfast · 9:40am Ferry to Paros",
+        desc: "One last breakfast in Mykonos, then the 9:40am high-speed ferry south — roughly 40 minutes across brilliant blue water.",
+        tags: [{ kind: "transport", label: "Mykonos → Paros · 9:40am ferry" }],
       },
     ],
   },
@@ -258,19 +266,22 @@ export const stops: Stop[] = [
     number: "04",
     tag: "Island Two",
     name: { em: "Paros", trail: ", Greece" },
-    dates: "August 28–29 · 2 nights",
+    dates: "August 28–30 · 2 nights",
     days: [
       {
         id: "par-aug28",
         dateLabel: "Aug 28",
         part: "Arrival",
         title: "Welcome to a Quieter Island",
-        desc: "Paros is the antidote to Mykonos — still gorgeous, still Cycladic, but calmer. The harbor at Naoussa is one of the prettiest in Greece. Arrive, find your hotel, breathe.",
+        desc: "Paros is the antidote to Mykonos — still gorgeous, still Cycladic, but calmer. Check in at the Argonauta Hotel in Parikia. The harbor at Naoussa is one of the prettiest in Greece. Arrive, settle in, breathe.",
         tags: [
-          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "stay", label: "Argonauta Hotel" },
           { kind: "food", label: "Dinner in Naoussa" },
         ],
-        spots: [{ name: "Naoussa", mapsQuery: "Naoussa, Paros, Greece" }],
+        spots: [
+          { name: "Argonauta Hotel", mapsQuery: "Argonauta Hotel Paros" },
+          { name: "Naoussa", mapsQuery: "Naoussa, Paros, Greece" },
+        ],
       },
       {
         id: "par-aug29",
@@ -289,9 +300,9 @@ export const stops: Stop[] = [
         id: "par-aug30",
         dateLabel: "Aug 30",
         part: "Morning",
-        title: "Breakfast · Ferry to Milos",
-        desc: "Morning coffee in Paros, then the ferry southwest to Milos — about 1 hour 45 on the fastest service.",
-        tags: [{ kind: "transport", label: "Paros → Milos · ~1h 45m ferry" }],
+        title: "Breakfast · 10:10am Ferry to Milos",
+        desc: "Morning coffee in Paros, then the 10:10am ferry southwest to Milos — about 1 hour 45 on the fastest service.",
+        tags: [{ kind: "transport", label: "Paros → Milos · 10:10am ferry" }],
       },
     ],
   },
@@ -307,10 +318,16 @@ export const stops: Stop[] = [
         dateLabel: "Aug 30",
         part: "Arrival",
         title: "The Volcanic Island",
-        desc: "Milos is arguably the most dramatic landscape in the Cyclades — shaped by ancient volcanism into lunar-white cliffs, turquoise coves, and sulfuric hot springs. Check in and explore.",
+        desc: "Milos is arguably the most dramatic landscape in the Cyclades — shaped by ancient volcanism into lunar-white cliffs, turquoise coves, and sulfuric hot springs. Check in at Salt Suites (by Mr & Mrs White) and explore.",
         tags: [
-          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "stay", label: "Salt Suites" },
           { kind: "activity", label: "Rent Car or Scooter" },
+        ],
+        spots: [
+          {
+            name: "Salt Suites by Mr & Mrs White",
+            mapsQuery: "Salt Suites Milos",
+          },
         ],
       },
       {
@@ -335,10 +352,13 @@ export const stops: Stop[] = [
         dateLabel: "Sep 1",
         part: "Morning",
         title: "Early Flight · Athens Layover · On to Nice",
-        desc: "Early Olympic Air flight from Milos (MLO) to Athens — about 40 minutes. A long but manageable layover at Athens before the afternoon Aegean flight to Nice. Arrive on the Riviera in time for dinner.",
+        desc: "Early Sky Express flight from Milos (GQ 419, 8:55am) to Athens — about 40 minutes. A layover at Athens, then the early-afternoon Aegean flight to Nice (A3 690, 1:35pm). Arrive on the Riviera in time for dinner.",
         tags: [
-          { kind: "transport", label: "MLO → ATH · Olympic Air · ~40 min" },
-          { kind: "transport", label: "ATH → NCE · Aegean A3 690" },
+          {
+            kind: "transport",
+            label: "MLO → ATH · Sky Express GQ 419 · 8:55am",
+          },
+          { kind: "transport", label: "ATH → NCE · Aegean A3 690 · 1:35pm" },
         ],
       },
     ],
@@ -348,19 +368,20 @@ export const stops: Stop[] = [
     number: "06",
     tag: "Stop Two",
     name: { em: "Nice", trail: ", Côte d'Azur" },
-    dates: "September 1–3 · 3 nights",
+    dates: "September 1–4 · 3 nights",
     days: [
       {
         id: "nce-sep1",
         dateLabel: "Sep 1",
         part: "Arrival",
         title: "Bienvenue sur la Riviera",
-        desc: "Arrive early evening from Athens. The Promenade des Anglais, Vieux-Nice, and the best rosé in the world are waiting. A light dinner and an early night — the Riviera rewards those who sleep.",
+        desc: "Arrive early afternoon from Athens and check in at Le Méridien Nice, right on the Promenade des Anglais. Vieux-Nice and the best rosé in the world are waiting. A light dinner and an early night — the Riviera rewards those who sleep.",
         tags: [
-          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "stay", label: "Le Méridien Nice" },
           { kind: "food", label: "Dinner in Vieux-Nice" },
         ],
         spots: [
+          { name: "Le Méridien Nice", mapsQuery: "Le Méridien Nice" },
           {
             name: "Promenade des Anglais",
             mapsQuery: "Promenade des Anglais, Nice",
@@ -413,18 +434,19 @@ export const stops: Stop[] = [
     number: "07",
     tag: "Grand Finale",
     name: { em: "New York", trail: " City" },
-    dates: "September 4–7 · US Open",
+    dates: "September 4–8 · US Open",
     days: [
       {
         id: "nyc-sep4",
         dateLabel: "Sep 4",
         part: "Arrival",
         title: "Into New York",
-        desc: "La Compagnie into Newark — all-business class, so you arrive refreshed. Transfer to the hotel in the city. New York hits differently after two weeks in Europe.",
+        desc: "La Compagnie into Newark (B0 200, 12:25pm dep) — all-business class, so you arrive refreshed. Transfer to the Moxy NYC Chelsea. New York hits differently after two weeks in Europe.",
         tags: [
-          { kind: "stay", label: "Hotel Check-in" },
+          { kind: "stay", label: "Moxy NYC Chelsea" },
           { kind: "food", label: "Welcome Back to America Dinner" },
         ],
+        spots: [{ name: "Moxy NYC Chelsea", mapsQuery: "Moxy NYC Chelsea" }],
       },
       {
         id: "nyc-sep5",
@@ -447,11 +469,11 @@ export const stops: Stop[] = [
         id: "nyc-sep6",
         dateLabel: "Sep 6",
         part: "Full Day",
-        title: "The City · Final Dinner",
-        desc: "A last full day in New York — whatever you want it to be: a museum, a walk across the Brooklyn Bridge, shopping, a long brunch. End with a dinner worth remembering.",
+        title: "The City",
+        desc: "A day in New York — whatever you want it to be: a museum, a walk across the Brooklyn Bridge, shopping in SoHo, a long brunch.",
         tags: [
           { kind: "activity", label: "Explore NYC" },
-          { kind: "food", label: "Farewell Dinner — make it special" },
+          { kind: "food", label: "Dinner Out" },
         ],
         spots: [
           { name: "Brooklyn Bridge", mapsQuery: "Brooklyn Bridge, New York" },
@@ -459,12 +481,23 @@ export const stops: Stop[] = [
       },
       {
         id: "nyc-sep7",
-        dateLabel: "Sep 7+",
+        dateLabel: "Sep 7",
+        part: "Last Full Day",
+        title: "Final New York Day · Farewell Dinner",
+        desc: "The last full day of the honeymoon. Whatever you've been saving for the end — and a dinner worth remembering before flying home tomorrow.",
+        tags: [
+          { kind: "activity", label: "Explore NYC" },
+          { kind: "food", label: "Farewell Dinner — make it special" },
+        ],
+      },
+      {
+        id: "nyc-sep8",
+        dateLabel: "Sep 8+",
         part: "Home",
         title: "Back to Chicago · Recovery",
-        desc: "Fly home to O'Hare and Wrigleyville (return date still being finalized — 9/9 or 9/10), with recovery and a spa day through Sep 13. The honeymoon ends, the marriage continues.",
+        desc: "Fly home to O'Hare on Delta (DL 2240), then recovery and a spa day through Sep 13. The honeymoon ends, the marriage continues.",
         tags: [
-          { kind: "transport", label: "NYC → ORD" },
+          { kind: "transport", label: "NYC → ORD · DL 2240" },
           { kind: "activity", label: "Spa / Recovery Day" },
           { kind: "transport", label: "Home ❤" },
         ],
@@ -485,57 +518,42 @@ export const transits: Transit[] = [
   {
     id: "t-myk-par",
     icon: "⛴",
-    lead: "Aug 28",
-    text: "High-speed ferry · Mykonos → Paros · SeaJets / Golden Star · ~40 min",
-    booked: false,
-    badge: "Confirm time",
+    lead: "Aug 28 · 9:40am",
+    text: "High-speed ferry · Mykonos → Paros · ~40 minutes",
+    booked: true,
   },
   {
     id: "t-par-mil",
     icon: "⛴",
-    lead: "Aug 30",
+    lead: "Aug 30 · 10:10am",
     text: "High-speed ferry · Paros → Milos · ~1 hour 45 minutes",
-    booked: false,
-    badge: "Confirm time",
+    booked: true,
   },
   {
     id: "t-mil-nce",
     icon: "✈",
     lead: "Sep 1",
-    text: "Olympic Air: MLO → ATH · then Aegean A3 690: ATH 16:25 → NCE 18:05",
+    text: "Sky Express GQ 419: MLO 8:55am → ATH · then Aegean A3 690: ATH 1:35pm → NCE",
     booked: true,
   },
   {
     id: "t-nce-nyc",
     icon: "✈",
-    lead: "Sep 4",
+    lead: "Sep 4 · 12:25pm",
     text: "La Compagnie B0 200 all-business · NCE → EWR · Direct",
+    booked: true,
+  },
+  {
+    id: "t-nyc-ord",
+    icon: "✈",
+    lead: "Sep 8",
+    text: "Delta DL 2240 · New York → Chicago O'Hare",
     booked: true,
   },
 ]
 
 // ── CHECKLIST (To Book / Packing / Before We Go) ───────────────────────────────
 export const checklist: ChecklistItem[] = [
-  {
-    id: "cl-ferry1",
-    label: "Book Mykonos → Paros ferry (FerryHopper)",
-    category: "To Book",
-  },
-  {
-    id: "cl-ferry2",
-    label: "Book Paros → Milos ferry (FerryHopper)",
-    category: "To Book",
-  },
-  {
-    id: "cl-hotels",
-    label: "Confirm all 6 hotels (London, 3 islands, Nice, NYC)",
-    category: "To Book",
-  },
-  {
-    id: "cl-nycflight",
-    label: "Book return NYC → ORD flight (9/9 or 9/10)",
-    category: "To Book",
-  },
   {
     id: "cl-usopen",
     label: "Buy US Open tickets (Arthur Ashe)",
@@ -559,6 +577,11 @@ export const checklist: ChecklistItem[] = [
   {
     id: "cl-milosboat",
     label: "Book Kleftiko boat tour (Milos)",
+    category: "To Book",
+  },
+  {
+    id: "cl-antiparos",
+    label: "Book Antiparos sailboat day (Paros)",
     category: "To Book",
   },
   {
@@ -607,8 +630,8 @@ export const budget: BudgetItem[] = [
     est: true,
   },
   {
-    id: "b-a3690",
-    label: "Flight · Olympic + Aegean A3 690 →Nice",
+    id: "b-greece",
+    label: "Flights · Sky Express GQ 419 + Aegean A3 690 →Nice",
     amount: 450,
     booked: true,
     est: true,
@@ -621,26 +644,19 @@ export const budget: BudgetItem[] = [
     est: true,
   },
   {
-    id: "b-nycord",
-    label: "Flight · NYC→ORD return",
+    id: "b-dl2240",
+    label: "Flight · Delta DL 2240 NYC→ORD (Sep 8)",
     amount: 120,
-    booked: false,
+    booked: true,
     est: true,
   },
   {
     id: "b-ferries",
     label: "Greek island ferries (×2)",
     amount: 0,
-    booked: false,
-    est: true,
+    booked: true,
   },
-  {
-    id: "b-hotels",
-    label: "Hotels (6 stops)",
-    amount: 0,
-    booked: false,
-    est: true,
-  },
+  { id: "b-hotels", label: "Hotels (6 stops)", amount: 0, booked: true },
   {
     id: "b-usopen",
     label: "US Open tickets",

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -37,6 +37,8 @@ export interface Tag {
 export interface Day {
   /** Stable id — used to persist check-off + notes in localStorage. Don't reuse. */
   id: string
+  /** Real calendar date, ISO yyyy-mm-dd — powers "today" detection. */
+  date: string
   dateLabel: string // e.g. "Aug 24"
   part: string // e.g. "Arrival" / "Full Day" / "Morning"
   title: string
@@ -127,6 +129,7 @@ export const stops: Stop[] = [
     days: [
       {
         id: "dep-aug23",
+        date: "2026-08-23",
         dateLabel: "Aug 23",
         part: "Evening",
         title: "Depart O'Hare for London Heathrow",
@@ -154,6 +157,7 @@ export const stops: Stop[] = [
     days: [
       {
         id: "lon-aug24",
+        date: "2026-08-24",
         dateLabel: "Aug 24",
         part: "Day 1 · Arrival",
         title: "Land 11:15am · Bankside & Borough Market",
@@ -193,6 +197,7 @@ export const stops: Stop[] = [
       },
       {
         id: "lon-aug25",
+        date: "2026-08-25",
         dateLabel: "Aug 25",
         part: "Day 2",
         title: "Shops · The Wallace Collection · Tea",
@@ -232,6 +237,7 @@ export const stops: Stop[] = [
     days: [
       {
         id: "myk-aug26",
+        date: "2026-08-26",
         dateLabel: "Aug 26",
         part: "Day 1 · Arrival",
         title: "Touch Down on the Cyclades",
@@ -251,6 +257,7 @@ export const stops: Stop[] = [
       },
       {
         id: "myk-aug27",
+        date: "2026-08-27",
         dateLabel: "Aug 27",
         part: "Full Day",
         title: "Elia Beach · Mykonos Town",
@@ -271,6 +278,7 @@ export const stops: Stop[] = [
       },
       {
         id: "myk-aug28",
+        date: "2026-08-28",
         dateLabel: "Aug 28",
         part: "Morning",
         title: "Early Breakfast · 9:40am Ferry to Paros",
@@ -288,6 +296,7 @@ export const stops: Stop[] = [
     days: [
       {
         id: "par-aug28",
+        date: "2026-08-28",
         dateLabel: "Aug 28",
         part: "Arrival",
         title: "Welcome to a Quieter Island",
@@ -303,6 +312,7 @@ export const stops: Stop[] = [
       },
       {
         id: "par-aug29",
+        date: "2026-08-29",
         dateLabel: "Aug 29",
         part: "Full Day",
         title: "Naoussa · Day Trip to Antiparos",
@@ -316,6 +326,7 @@ export const stops: Stop[] = [
       },
       {
         id: "par-aug30",
+        date: "2026-08-30",
         dateLabel: "Aug 30",
         part: "Morning",
         title: "Breakfast · 10:10am Ferry to Milos",
@@ -333,6 +344,7 @@ export const stops: Stop[] = [
     days: [
       {
         id: "mil-aug30",
+        date: "2026-08-30",
         dateLabel: "Aug 30",
         part: "Arrival",
         title: "The Volcanic Island",
@@ -350,6 +362,7 @@ export const stops: Stop[] = [
       },
       {
         id: "mil-aug31",
+        date: "2026-08-31",
         dateLabel: "Aug 31",
         part: "Full Day",
         title: "Sarakiniko · Kleftiko · Firopotamos",
@@ -367,6 +380,7 @@ export const stops: Stop[] = [
       },
       {
         id: "mil-sep1",
+        date: "2026-09-01",
         dateLabel: "Sep 1",
         part: "Morning",
         title: "Early Flight · Athens Layover · On to Nice",
@@ -390,6 +404,7 @@ export const stops: Stop[] = [
     days: [
       {
         id: "nce-sep1",
+        date: "2026-09-01",
         dateLabel: "Sep 1",
         part: "Arrival",
         title: "Bienvenue sur la Riviera",
@@ -412,6 +427,7 @@ export const stops: Stop[] = [
       },
       {
         id: "nce-sep2",
+        date: "2026-09-02",
         dateLabel: "Sep 2",
         part: "Full Day",
         title: "Nice · Èze · The Corniche",
@@ -429,6 +445,7 @@ export const stops: Stop[] = [
       },
       {
         id: "nce-sep3",
+        date: "2026-09-03",
         dateLabel: "Sep 3",
         part: "Full Day",
         title: "Day Trip: Monaco",
@@ -456,6 +473,7 @@ export const stops: Stop[] = [
     days: [
       {
         id: "nyc-sep4",
+        date: "2026-09-04",
         dateLabel: "Sep 4",
         part: "Arrival",
         title: "Into New York",
@@ -468,6 +486,7 @@ export const stops: Stop[] = [
       },
       {
         id: "nyc-sep5",
+        date: "2026-09-05",
         dateLabel: "Sep 5",
         part: "Saturday",
         title: "The City",
@@ -482,6 +501,7 @@ export const stops: Stop[] = [
       },
       {
         id: "nyc-sep6",
+        date: "2026-09-06",
         dateLabel: "Sep 6",
         part: "Sunday · Match Day",
         title: "US Open — Arthur Ashe Stadium",
@@ -500,6 +520,7 @@ export const stops: Stop[] = [
       },
       {
         id: "nyc-sep7",
+        date: "2026-09-07",
         dateLabel: "Sep 7",
         part: "Last Full Day",
         title: "Final New York Day · Farewell Dinner",
@@ -511,6 +532,7 @@ export const stops: Stop[] = [
       },
       {
         id: "nyc-sep8",
+        date: "2026-09-08",
         dateLabel: "Sep 8",
         part: "Home",
         title: "Back to Chicago",

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -451,24 +451,7 @@ export const stops: Stop[] = [
       {
         id: "nyc-sep5",
         dateLabel: "Sep 5",
-        part: "Match Day",
-        title: "US Open — Arthur Ashe Stadium",
-        desc: "The US Open runs Aug 31 – Sep 13; early September is the sweet spot — the best players still in it, the roar of the crowd, the best tennis in the world at Flushing Meadows.",
-        tags: [
-          { kind: "activity", label: "US Open · Arthur Ashe" },
-          { kind: "food", label: "Post-match Dinner" },
-        ],
-        spots: [
-          {
-            name: "Arthur Ashe Stadium",
-            mapsQuery: "Arthur Ashe Stadium, Flushing Meadows",
-          },
-        ],
-      },
-      {
-        id: "nyc-sep6",
-        dateLabel: "Sep 6",
-        part: "Full Day",
+        part: "Saturday",
         title: "The City",
         desc: "A day in New York — whatever you want it to be: a museum, a walk across the Brooklyn Bridge, shopping in SoHo, a long brunch.",
         tags: [
@@ -477,6 +460,24 @@ export const stops: Stop[] = [
         ],
         spots: [
           { name: "Brooklyn Bridge", mapsQuery: "Brooklyn Bridge, New York" },
+        ],
+      },
+      {
+        id: "nyc-sep6",
+        dateLabel: "Sep 6",
+        part: "Sunday · Match Day",
+        title: "US Open — Arthur Ashe Stadium",
+        desc: "Sunday at Flushing Meadows — the best players still in it, the roar of the crowd, the best tennis in the world. Tickets are booked.",
+        tags: [
+          { kind: "activity", label: "US Open · Arthur Ashe" },
+          { kind: "booked", label: "✓ Tickets Booked" },
+          { kind: "food", label: "Post-match Dinner" },
+        ],
+        spots: [
+          {
+            name: "Arthur Ashe Stadium",
+            mapsQuery: "Arthur Ashe Stadium, Flushing Meadows",
+          },
         ],
       },
       {
@@ -554,11 +555,6 @@ export const transits: Transit[] = [
 
 // ── CHECKLIST (To Book / Packing / Before We Go) ───────────────────────────────
 export const checklist: ChecklistItem[] = [
-  {
-    id: "cl-usopen",
-    label: "Buy US Open tickets (Arthur Ashe)",
-    category: "To Book",
-  },
   {
     id: "cl-westend",
     label: "Book West End show (London)",
@@ -659,9 +655,8 @@ export const budget: BudgetItem[] = [
   { id: "b-hotels", label: "Hotels (6 stops)", amount: 0, booked: true },
   {
     id: "b-usopen",
-    label: "US Open tickets",
+    label: "US Open tickets (Sun Sep 6)",
     amount: 0,
-    booked: false,
-    est: true,
+    booked: true,
   },
 ]

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -34,6 +34,35 @@ export interface Tag {
   label: string
 }
 
+// ── HOUR-BY-HOUR TIMELINE ──────────────────────────────────────────────────--
+// Optional granular schedule for a day. A day can have a narrative `desc` AND a
+// `timeline` — the timeline renders as a collapsible "hour-by-hour" sub-list
+// under the day card. Use it for days with real logistics (transfers, ferries,
+// reservation slots). Days without one just render the narrative as before.
+export type TimelineKind =
+  | "travel" // a transfer leg — taxi, ferry, flight, walk
+  | "meal" // food / wine
+  | "activity" // beach, town, sightseeing
+  | "checkin" // hotel arrival / settling in
+  | "downtime" // rest, nap, slow morning
+
+export interface TimelineEntry {
+  /** Clock label, e.g. "4:50pm". Keep them in chronological order. */
+  time: string
+  title: string
+  /** One line of specifics — what/where/why. */
+  detail?: string
+  kind: TimelineKind
+  /** How long the thing itself takes, e.g. "2h", "45 min". */
+  duration?: string
+  /** For `travel` legs: door-to-door estimate, e.g. "~20 min taxi". */
+  travelTime?: string
+  /** Reservation state — drives a small chip. */
+  booking?: "booked" | "to-book" | "walk-in"
+  /** Opens in Maps, same behavior as a Spot. */
+  mapsQuery?: string
+}
+
 export interface Day {
   /** Stable id — used to persist check-off + notes in localStorage. Don't reuse. */
   id: string
@@ -45,6 +74,8 @@ export interface Day {
   desc: string
   tags?: Tag[]
   spots?: Spot[]
+  /** Optional hour-by-hour breakdown (renders collapsed under the card). */
+  timeline?: TimelineEntry[]
 }
 
 export interface Stop {
@@ -240,19 +271,76 @@ export const stops: Stop[] = [
         date: "2026-08-26",
         dateLabel: "Aug 26",
         part: "Day 1 · Arrival",
-        title: "Touch Down on the Cyclades",
-        desc: "Depart Heathrow 10:55am on BA 668 and land in Mykonos around 4:50pm — the only Greek island with a direct Heathrow connection. Drop bags at Rocabella Mykonos, find the water, and let Greece begin.",
+        title: "Touch Down · Sunset in Little Venice",
+        desc: "Land around 4:50pm — the only Greek island with a direct Heathrow connection — and settle into Rocabella, up in quiet Agios Stefanos on the sunset side of the island. A drink on the terrace, then into Mykonos Town for golden hour over Little Venice and a long first dinner. An easy, no-club first night.",
         tags: [
           { kind: "stay", label: "Rocabella Mykonos" },
-          { kind: "food", label: "Dinner in Mykonos Town" },
+          { kind: "activity", label: "Little Venice Sunset" },
+          { kind: "food", label: "Dinner · M-eating" },
         ],
         spots: [
           {
             name: "Rocabella Mykonos",
-            mapsQuery: "Rocabella Mykonos Hotel",
+            mapsQuery: "Rocabella Mykonos Hotel Agios Stefanos",
           },
-          { name: "Mykonos Windmills", mapsQuery: "Windmills of Mykonos" },
           { name: "Little Venice", mapsQuery: "Little Venice, Mykonos" },
+          { name: "Galleraki", mapsQuery: "Galleraki Little Venice Mykonos" },
+          { name: "M-eating", mapsQuery: "M-eating restaurant Mykonos Town" },
+        ],
+        timeline: [
+          {
+            time: "4:50pm",
+            title: "Land at Mykonos (JMK)",
+            detail: "BA 668 from Heathrow — bags, then out to the taxi rank.",
+            kind: "travel",
+          },
+          {
+            time: "5:15pm",
+            title: "Transfer to Rocabella",
+            detail: "North to Agios Stefanos, the quiet sunset-facing side.",
+            kind: "travel",
+            travelTime: "~15 min taxi",
+            mapsQuery: "Rocabella Mykonos Hotel Agios Stefanos",
+          },
+          {
+            time: "5:40pm",
+            title: "Check in · arrival drink",
+            detail: "Drop bags, decompress on the terrace over the bay.",
+            kind: "checkin",
+            duration: "1h",
+          },
+          {
+            time: "7:15pm",
+            title: "Into Mykonos Town",
+            kind: "travel",
+            travelTime: "~12 min taxi",
+          },
+          {
+            time: "7:40pm",
+            title: "Sunset drinks · Galleraki",
+            detail:
+              "Waterfront table in Little Venice. Sunset ~8:00pm — grab the table early. (Skip Baos/Semeli — DJ-loud.)",
+            kind: "activity",
+            booking: "walk-in",
+            mapsQuery: "Galleraki Little Venice Mykonos",
+          },
+          {
+            time: "9:00pm",
+            title: "Dinner · M-eating",
+            detail:
+              "Cycladic tasting-menu cooking, serious Greek wine list. The honeymoon-night table.",
+            kind: "meal",
+            duration: "~2h",
+            booking: "to-book",
+            mapsQuery: "M-eating restaurant Mykonos Town",
+          },
+          {
+            time: "11:15pm",
+            title: "Wander back · taxi to Rocabella",
+            detail: "A loop past the windmills on the way out of town.",
+            kind: "travel",
+            travelTime: "~12 min taxi",
+          },
         ],
       },
       {
@@ -260,19 +348,88 @@ export const stops: Stop[] = [
         date: "2026-08-27",
         dateLabel: "Aug 27",
         part: "Full Day",
-        title: "Elia Beach · Mykonos Town",
-        desc: "Mykonos does beaches and nightlife better than almost anywhere. Elia or Super Paradise for the day, then Mykonos Town at sunset. Consider a beach club day with a minimum spend — Scorpios and Jackie O' are the iconic options.",
+        title: "Beach by Day · Gay Mykonos, Quietly, by Night",
+        desc: "The one full day. A relaxed luxe beach club where you can actually hear each other — Solymar on calm Kalo Livadi, not a Scorpios sound-system — then town at night the way it suits you: an intimate cocktail at Lola, the buzz of Jackie O' Town Bar soaked up from the street, and a second great dinner. (Easy to flip to an all-in-town day — swap the beach block for a slow Chora morning.)",
         tags: [
-          { kind: "activity", label: "Beach Club" },
-          { kind: "activity", label: "Town + Windmills" },
-          { kind: "food", label: "Drinks & Nightlife" },
+          { kind: "activity", label: "Solymar · Kalo Livadi" },
+          { kind: "food", label: "Dinner · Kalita" },
+          { kind: "activity", label: "Lola + Jackie O' (street)" },
         ],
         spots: [
-          { name: "Elia Beach", mapsQuery: "Elia Beach, Mykonos" },
-          { name: "Scorpios", mapsQuery: "Scorpios Mykonos" },
           {
-            name: "Jackie O' Beach",
-            mapsQuery: "Jackie O' Beach Club Mykonos",
+            name: "Solymar Beach Club",
+            mapsQuery: "Solymar Kalo Livadi Beach Mykonos",
+          },
+          { name: "Kalita", mapsQuery: "Kalita restaurant Mykonos Town" },
+          { name: "Lola Bar", mapsQuery: "Lola Bar Mykonos Town" },
+          {
+            name: "Jackie O' Town Bar",
+            mapsQuery: "Jackie O' Town Bar Mykonos old port",
+          },
+        ],
+        timeline: [
+          {
+            time: "9:30am",
+            title: "Slow breakfast at Rocabella",
+            kind: "downtime",
+            duration: "1.5h",
+          },
+          {
+            time: "11:30am",
+            title: "Out to Kalo Livadi",
+            kind: "travel",
+            travelTime: "~25 min taxi",
+            mapsQuery: "Solymar Kalo Livadi Beach Mykonos",
+          },
+          {
+            time: "12:00pm",
+            title: "Solymar · daybeds, swim, long lunch",
+            detail:
+              "Lounge/chill music by day, fine-dining lunch. Calm half of the beach — book a daybed ahead in August.",
+            kind: "activity",
+            duration: "~5h",
+            booking: "to-book",
+            mapsQuery: "Solymar Kalo Livadi Beach Mykonos",
+          },
+          {
+            time: "5:15pm",
+            title: "Back to the hotel · rest & shower",
+            kind: "downtime",
+            travelTime: "~25 min taxi",
+          },
+          {
+            time: "8:15pm",
+            title: "Dinner · Kalita",
+            detail:
+              "Refined Greek in town. (Or swap for Nobu/Matsuhisa — book days ahead.)",
+            kind: "meal",
+            duration: "~2h",
+            booking: "to-book",
+            mapsQuery: "Kalita restaurant Mykonos Town",
+          },
+          {
+            time: "10:30pm",
+            title: "Cocktail at Lola",
+            detail:
+              "Small, intimate, conversation-friendly — the one gay bar built for people who don't love loud rooms.",
+            kind: "activity",
+            booking: "walk-in",
+            mapsQuery: "Lola Bar Mykonos Town",
+          },
+          {
+            time: "11:30pm",
+            title: "Past Jackie O' Town Bar",
+            detail:
+              "The heart of gay Mykonos spills into the street by the old port — soak up the buzz, no sweaty club required.",
+            kind: "activity",
+            booking: "walk-in",
+            mapsQuery: "Jackie O' Town Bar Mykonos old port",
+          },
+          {
+            time: "12:30am",
+            title: "Taxi back to Rocabella",
+            kind: "travel",
+            travelTime: "~12 min taxi",
           },
         ],
       },
@@ -284,6 +441,29 @@ export const stops: Stop[] = [
         title: "Early Breakfast · 9:40am Ferry to Paros",
         desc: "One last breakfast in Mykonos, then the 9:40am high-speed ferry south — about 45 minutes, arriving Paros around 10:25am.",
         tags: [{ kind: "transport", label: "Mykonos → Paros · 9:40am ferry" }],
+        timeline: [
+          {
+            time: "8:00am",
+            title: "Breakfast & pack up",
+            kind: "downtime",
+            duration: "45 min",
+          },
+          {
+            time: "8:50am",
+            title: "Taxi to the New Port",
+            detail: "Buffer for August port chaos — be there ~30 min early.",
+            kind: "travel",
+            travelTime: "~15 min taxi",
+            mapsQuery: "Mykonos New Port",
+          },
+          {
+            time: "9:40am",
+            title: "High-speed ferry to Paros",
+            detail: "~45 min crossing, arrives Paros ~10:25am.",
+            kind: "travel",
+            booking: "booked",
+          },
+        ],
       },
     ],
   },
@@ -610,8 +790,13 @@ export const checklist: ChecklistItem[] = [
     category: "To Book",
   },
   {
+    id: "cl-myk-dinners",
+    label: "Reserve Mykonos dinners — M-eating (26th) + Kalita/Nobu (27th)",
+    category: "To Book",
+  },
+  {
     id: "cl-beachclub",
-    label: "Reserve Mykonos beach club (Scorpios / Jackie O')",
+    label: "Reserve Solymar daybed, Kalo Livadi (Aug 27)",
     category: "To Book",
   },
   {

--- a/src/data/honeymoon.ts
+++ b/src/data/honeymoon.ts
@@ -348,19 +348,23 @@ export const stops: Stop[] = [
         date: "2026-08-27",
         dateLabel: "Aug 27",
         part: "Full Day",
-        title: "Beach by Day · Gay Mykonos, Quietly, by Night",
-        desc: "The one full day. A relaxed luxe beach club where you can actually hear each other — Solymar on calm Kalo Livadi, not a Scorpios sound-system — then town at night the way it suits you: an intimate cocktail at Lola, the buzz of Jackie O' Town Bar soaked up from the street, and a second great dinner. (Easy to flip to an all-in-town day — swap the beach block for a slow Chora morning.)",
+        title: "Old Port Morning · Jackie O' Beach · Hippie Fish",
+        desc: "The one full day. A slow morning wander through the Old Port and Chora before the day-trippers flood in, then out to Jackie O' Beach Club on Super Paradise — arrive by noon to claim chairs. Back to the hotel to rinse off, then dinner at Hippie Fish on Agios Ioannis beach at 8pm. Town afterward if the night wants it: a cocktail at Lola, the Jackie O' Town Bar buzz from the street.",
         tags: [
-          { kind: "activity", label: "Solymar · Kalo Livadi" },
-          { kind: "food", label: "Dinner · Kalita" },
-          { kind: "activity", label: "Lola + Jackie O' (street)" },
+          { kind: "activity", label: "Old Port Morning" },
+          { kind: "activity", label: "Jackie O' Beach Club" },
+          { kind: "food", label: "Hippie Fish · 8pm" },
         ],
         spots: [
+          { name: "Mykonos Old Port", mapsQuery: "Old Port, Mykonos Town" },
           {
-            name: "Solymar Beach Club",
-            mapsQuery: "Solymar Kalo Livadi Beach Mykonos",
+            name: "Jackie O' Beach Club",
+            mapsQuery: "Jackie O' Beach Club Super Paradise Mykonos",
           },
-          { name: "Kalita", mapsQuery: "Kalita restaurant Mykonos Town" },
+          {
+            name: "Hippie Fish",
+            mapsQuery: "Hippie Fish Agios Ioannis Mykonos",
+          },
           { name: "Lola Bar", mapsQuery: "Lola Bar Mykonos Town" },
           {
             name: "Jackie O' Town Bar",
@@ -369,27 +373,36 @@ export const stops: Stop[] = [
         ],
         timeline: [
           {
-            time: "9:30am",
-            title: "Slow breakfast at Rocabella",
+            time: "8:45am",
+            title: "Breakfast at Rocabella",
             kind: "downtime",
-            duration: "1.5h",
+            duration: "1h",
+          },
+          {
+            time: "10:00am",
+            title: "Old Port + Chora stroll",
+            detail:
+              "Morning light on the harbor, coffee, the alleys before the crowds.",
+            kind: "activity",
+            travelTime: "~12 min taxi in",
+            mapsQuery: "Old Port, Mykonos Town",
           },
           {
             time: "11:30am",
-            title: "Out to Kalo Livadi",
+            title: "Out to Super Paradise",
             kind: "travel",
-            travelTime: "~25 min taxi",
-            mapsQuery: "Solymar Kalo Livadi Beach Mykonos",
+            travelTime: "~20 min taxi",
+            mapsQuery: "Jackie O' Beach Club Super Paradise Mykonos",
           },
           {
             time: "12:00pm",
-            title: "Solymar · daybeds, swim, long lunch",
+            title: "Jackie O' Beach Club · chairs by noon",
             detail:
-              "Lounge/chill music by day, fine-dining lunch. Calm half of the beach — book a daybed ahead in August.",
+              "Arrive by 12pm to get chairs — no reservation, just be early. Swim, long lunch, the classic gay beach day.",
             kind: "activity",
             duration: "~5h",
-            booking: "to-book",
-            mapsQuery: "Solymar Kalo Livadi Beach Mykonos",
+            booking: "walk-in",
+            mapsQuery: "Jackie O' Beach Club Super Paradise Mykonos",
           },
           {
             time: "5:15pm",
@@ -398,14 +411,14 @@ export const stops: Stop[] = [
             travelTime: "~25 min taxi",
           },
           {
-            time: "8:15pm",
-            title: "Dinner · Kalita",
+            time: "8:00pm",
+            title: "Dinner · Hippie Fish",
             detail:
-              "Refined Greek in town. (Or swap for Nobu/Matsuhisa — book days ahead.)",
+              "Toes-in-the-sand seafood on Agios Ioannis beach, 8pm table.",
             kind: "meal",
             duration: "~2h",
-            booking: "to-book",
-            mapsQuery: "Kalita restaurant Mykonos Town",
+            booking: "booked",
+            mapsQuery: "Hippie Fish Agios Ioannis Mykonos",
           },
           {
             time: "10:30pm",
@@ -610,17 +623,25 @@ export const stops: Stop[] = [
         date: "2026-09-02",
         dateLabel: "Sep 2",
         part: "Full Day",
-        title: "Nice · Èze · The Corniche",
-        desc: "A perfect Riviera day: the Old Town market in the morning, then the Grande Corniche to the perched village of Èze for lunch and vertigo-inducing views. Spa in the afternoon if the mood strikes.",
+        title: "In-Town Day · Matisse · Castle Hill · Beach",
+        desc: "A local Nice day: the Cours Saleya market and Vieux-Nice in the morning, the Matisse Museum up in Cimiez (~13 min drive), the Castle Hill walk above the old town, and a lazy stretch on the beach. If the mood strikes, the Clos Saint-Vincent winery is about 30 minutes out.",
         tags: [
-          { kind: "activity", label: "Cours Saleya Market" },
-          { kind: "activity", label: "Èze Village" },
-          { kind: "activity", label: "Spa Day" },
-          { kind: "food", label: "Fancy Dinner" },
+          { kind: "activity", label: "Matisse Museum" },
+          { kind: "activity", label: "Castle Hill" },
+          { kind: "activity", label: "Beach + Winery" },
+          { kind: "food", label: "Dinner in Town" },
         ],
         spots: [
           { name: "Cours Saleya Market", mapsQuery: "Cours Saleya, Nice" },
-          { name: "Èze Village", mapsQuery: "Èze, France" },
+          { name: "Matisse Museum", mapsQuery: "Musée Matisse, Nice" },
+          {
+            name: "Castle Hill",
+            mapsQuery: "Colline du Château, Nice",
+          },
+          {
+            name: "Clos Saint-Vincent",
+            mapsQuery: "Clos Saint-Vincent winery Nice",
+          },
         ],
       },
       {
@@ -628,17 +649,22 @@ export const stops: Stop[] = [
         date: "2026-09-03",
         dateLabel: "Sep 3",
         part: "Full Day",
-        title: "Day Trip: Monaco",
-        desc: "A 20-minute train ride to the most glamorous microstate in Europe. The Casino de Monte-Carlo, a harbor full of superyachts, a long lunch overlooking it all. Back to Nice for a final Riviera dinner.",
+        title: "Private Guide Day on the Riviera",
+        desc: "A driver/guide for the day (~€350) to do the coast properly — the Picasso Museum in Antibes, the Antibes markets, the Fragonard perfume factory, the perched village of Èze. Back to Nice for a final Riviera dinner.",
         tags: [
-          { kind: "activity", label: "Monaco Day Trip" },
-          { kind: "activity", label: "Casino de Monte-Carlo" },
+          { kind: "activity", label: "Private Driver/Guide" },
+          { kind: "activity", label: "Antibes · Èze · Fragonard" },
           { kind: "food", label: "Final Nice Dinner" },
         ],
         spots: [
           {
-            name: "Casino de Monte-Carlo",
-            mapsQuery: "Casino de Monte-Carlo, Monaco",
+            name: "Picasso Museum, Antibes",
+            mapsQuery: "Musée Picasso, Antibes",
+          },
+          { name: "Èze Village", mapsQuery: "Èze, France" },
+          {
+            name: "Fragonard Factory",
+            mapsQuery: "Fragonard perfume factory Èze",
           },
         ],
       },
@@ -657,26 +683,34 @@ export const stops: Stop[] = [
         dateLabel: "Sep 4",
         part: "Arrival",
         title: "Into New York",
-        desc: "La Compagnie B0 200 departs Nice 12:25pm and lands at Newark around 3:45pm — all-business class, so you arrive refreshed. Transfer to the Moxy NYC Chelsea. New York hits differently after two weeks in Europe.",
+        desc: "La Compagnie B0 200 departs Nice 12:25pm and lands at Newark around 3:45pm — all-business class, so you arrive refreshed. Transfer to the Moxy NYC Chelsea, then keep it easy: chill Thai dinner and drinks at Sappesan.",
         tags: [
           { kind: "stay", label: "Moxy NYC Chelsea" },
-          { kind: "food", label: "Welcome Back to America Dinner" },
+          { kind: "food", label: "Thai at Sappesan" },
         ],
-        spots: [{ name: "Moxy NYC Chelsea", mapsQuery: "Moxy NYC Chelsea" }],
+        spots: [
+          { name: "Moxy NYC Chelsea", mapsQuery: "Moxy NYC Chelsea" },
+          { name: "Sappesan", mapsQuery: "Sappesan Thai New York" },
+        ],
       },
       {
         id: "nyc-sep5",
         date: "2026-09-05",
         dateLabel: "Sep 5",
         part: "Saturday",
-        title: "The City",
-        desc: "A day in New York — whatever you want it to be: a museum, a walk across the Brooklyn Bridge, shopping in SoHo, a long brunch.",
+        title: "The City · Cat Cohen at Night",
+        desc: "A day in New York — whatever you want it to be: a museum, a walk across the Brooklyn Bridge, shopping in SoHo, a long brunch. Dinner at Aria Wine Bar in the West Village (reservation needed), then Cat Cohen: Broad Strokes at 8:15pm.",
         tags: [
           { kind: "activity", label: "Explore NYC" },
-          { kind: "food", label: "Dinner Out" },
+          { kind: "food", label: "Aria Wine Bar · WV" },
+          { kind: "activity", label: "Cat Cohen · 8:15pm" },
         ],
         spots: [
           { name: "Brooklyn Bridge", mapsQuery: "Brooklyn Bridge, New York" },
+          {
+            name: "Aria Wine Bar",
+            mapsQuery: "Aria Wine Bar West Village New York",
+          },
         ],
       },
       {
@@ -685,11 +719,11 @@ export const stops: Stop[] = [
         dateLabel: "Sep 6",
         part: "Sunday · Match Day",
         title: "US Open — Arthur Ashe Stadium",
-        desc: "Sunday at Flushing Meadows — the best players still in it, the roar of the crowd, the best tennis in the world. Tickets are booked.",
+        desc: "Sunday at Flushing Meadows — the best players still in it, the roar of the crowd, the best tennis in the world. Tickets are booked. Post-match, Chinese food around Grand Central on the way back into Manhattan.",
         tags: [
           { kind: "activity", label: "US Open · Arthur Ashe" },
           { kind: "booked", label: "✓ Tickets Booked" },
-          { kind: "food", label: "Post-match Dinner" },
+          { kind: "food", label: "Chinese near Grand Central" },
         ],
         spots: [
           {
@@ -791,12 +825,13 @@ export const checklist: ChecklistItem[] = [
   },
   {
     id: "cl-myk-dinners",
-    label: "Reserve Mykonos dinners — M-eating (26th) + Kalita/Nobu (27th)",
+    label:
+      "Reserve M-eating, Mykonos (Aug 26) — Hippie Fish 8pm on the 27th is set",
     category: "To Book",
   },
   {
-    id: "cl-beachclub",
-    label: "Reserve Solymar daybed, Kalo Livadi (Aug 27)",
+    id: "cl-aria",
+    label: "Reserve Aria Wine Bar, West Village (Sep 5)",
     category: "To Book",
   },
   {

--- a/src/pages/honeymoon.astro
+++ b/src/pages/honeymoon.astro
@@ -145,6 +145,15 @@ import HoneymoonTracker from "../components/HoneymoonTracker"
     text-transform: uppercase;
     color: rgba(245, 240, 232, 0.5);
     font-weight: 400;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.15rem 0.1rem;
+    font-family: "Jost", sans-serif;
+    transition: color 0.2s ease;
+  }
+  .hero-route-stop:hover {
+    color: var(--cream);
   }
   .hero-route-stop.highlight {
     color: var(--warm);
@@ -278,6 +287,113 @@ import HoneymoonTracker from "../components/HoneymoonTracker"
     color: var(--muted);
     font-weight: 500;
     white-space: nowrap;
+  }
+
+  /* ── STATUS / TODAY BANNER ── */
+  .status {
+    background: var(--ink);
+    color: var(--cream);
+    text-align: center;
+    padding: 0.7rem 2rem;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+  .status strong {
+    color: var(--warm);
+    font-weight: 500;
+  }
+  .status-during {
+    background: var(--terracotta);
+  }
+  .status-during strong {
+    color: var(--cream);
+  }
+  .status-btn {
+    background: rgba(245, 240, 232, 0.15);
+    border: 1px solid rgba(245, 240, 232, 0.4);
+    color: var(--cream);
+    font-family: "Jost", sans-serif;
+    font-size: 0.6rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    padding: 0.3rem 0.7rem;
+    border-radius: 2rem;
+    cursor: pointer;
+  }
+  .status-btn:hover {
+    background: rgba(245, 240, 232, 0.28);
+  }
+
+  /* ── SUB-BAR: view toggle + stop nav ── */
+  .subbar {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 0 2rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .viewtoggle {
+    display: flex;
+    flex: 0 0 auto;
+    border: 1px solid var(--sand);
+    border-radius: 2rem;
+    overflow: hidden;
+  }
+  .vt {
+    font-family: "Jost", sans-serif;
+    font-size: 0.6rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    font-weight: 500;
+    padding: 0.4rem 0.8rem;
+    background: transparent;
+    color: var(--muted);
+    border: none;
+    cursor: pointer;
+  }
+  .vt.active {
+    background: var(--warm);
+    color: var(--deep);
+  }
+  .stopnav {
+    display: flex;
+    gap: 0.35rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+    flex: 1;
+  }
+  .stopnav::-webkit-scrollbar {
+    display: none;
+  }
+  .stopchip {
+    font-family: "Jost", sans-serif;
+    font-size: 0.58rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 500;
+    white-space: nowrap;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--sand);
+    background: transparent;
+    color: var(--muted);
+    border-radius: 2rem;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .stopchip:hover {
+    color: var(--ink);
+    border-color: var(--warm);
+  }
+  .stopchip.current {
+    background: var(--terracotta);
+    color: var(--cream);
+    border-color: var(--terracotta);
   }
 
   /* ── MAIN CONTENT ── */
@@ -760,6 +876,234 @@ import HoneymoonTracker from "../components/HoneymoonTracker"
     border-radius: 4px;
   }
 
+  /* ── TODAY HIGHLIGHT ── */
+  .day-card.today::before {
+    background: var(--terracotta);
+    border-color: var(--terracotta);
+    box-shadow: 0 0 0 4px rgba(181, 98, 58, 0.18);
+  }
+  .day-card.today {
+    background: linear-gradient(
+      90deg,
+      rgba(181, 98, 58, 0.07),
+      transparent 70%
+    );
+    border-radius: 10px;
+  }
+  .today-pill {
+    display: inline-block;
+    margin-left: 0.5rem;
+    font-size: 0.5rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    background: var(--terracotta);
+    color: var(--cream);
+    padding: 0.15rem 0.45rem;
+    border-radius: 2rem;
+    vertical-align: middle;
+  }
+  .destination.current-stop .dest-number {
+    color: var(--warm);
+  }
+
+  /* ── PER-DAY DETAILS ── */
+  .details {
+    margin-top: 0.85rem;
+  }
+  .details-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .mini-btn {
+    font-family: "Jost", sans-serif;
+    font-size: 0.58rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 500;
+    padding: 0.3rem 0.65rem;
+    border: 1px solid var(--sand);
+    border-radius: 2rem;
+    background: transparent;
+    color: var(--sea);
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.15s ease;
+  }
+  .mini-btn:hover {
+    border-color: var(--warm);
+    color: var(--terracotta);
+  }
+  .mini-btn.link-live {
+    color: var(--sage);
+    border-color: rgba(122, 140, 110, 0.5);
+  }
+  .conf-chip {
+    font-size: 0.6rem;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    font-style: italic;
+  }
+  .details-fields {
+    margin-top: 0.7rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.7rem;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .field-wide {
+    grid-column: 1 / -1;
+  }
+  .field-label {
+    font-size: 0.55rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+  }
+  .field-input {
+    font-family: "Jost", sans-serif;
+    font-size: 0.82rem;
+    color: var(--ink);
+    background: rgba(255, 255, 255, 0.5);
+    border: 1px solid var(--sand);
+    border-radius: 8px;
+    padding: 0.5rem 0.7rem;
+    width: 100%;
+  }
+  .field-input:focus {
+    outline: none;
+    border-color: var(--warm);
+  }
+  .note-input {
+    min-height: 70px;
+    resize: vertical;
+    line-height: 1.6;
+  }
+
+  /* ── AGENDA VIEW ── */
+  .agenda-stop {
+    padding-top: 2rem;
+  }
+  .agenda-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid var(--sand);
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
+    position: sticky;
+    top: 0;
+    background: var(--cream);
+  }
+  .agenda-head.current {
+    border-color: var(--terracotta);
+  }
+  .agenda-stop-name {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 1.6rem;
+    font-weight: 400;
+    color: var(--ink);
+  }
+  .agenda-stop-dates {
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .agenda-row {
+    display: grid;
+    grid-template-columns: auto 88px 1fr;
+    gap: 0.8rem;
+    align-items: start;
+    padding: 0.7rem 0.3rem;
+    border-bottom: 1px solid rgba(232, 220, 200, 0.5);
+  }
+  .agenda-row.today {
+    background: rgba(181, 98, 58, 0.07);
+    border-radius: 8px;
+  }
+  .agenda-check {
+    width: 20px;
+    height: 20px;
+    flex: 0 0 auto;
+    border: 1.5px solid var(--warm);
+    border-radius: 5px;
+    background: transparent;
+    color: var(--cream);
+    font-size: 0.7rem;
+    cursor: pointer;
+    margin-top: 0.1rem;
+  }
+  .agenda-check.checked {
+    background: var(--terracotta);
+    border-color: var(--terracotta);
+  }
+  .agenda-when {
+    display: flex;
+    flex-direction: column;
+  }
+  .agenda-date {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 1.05rem;
+    color: var(--ink);
+    line-height: 1.1;
+  }
+  .agenda-part {
+    font-size: 0.55rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .agenda-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .agenda-title {
+    font-size: 0.9rem;
+    color: var(--ink);
+  }
+  .agenda-row.done .agenda-title {
+    text-decoration: line-through;
+    text-decoration-color: var(--warm);
+    color: var(--muted);
+  }
+  .agenda-maps {
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--sea);
+    text-decoration: none;
+    width: fit-content;
+  }
+  .agenda-maps:hover {
+    color: var(--terracotta);
+  }
+  .agenda-transit {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 0.8rem;
+    margin: 0.5rem 0 0.5rem;
+    background: var(--deep);
+    border-radius: 8px;
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(245, 240, 232, 0.6);
+  }
+  .agenda-transit strong {
+    color: var(--warm);
+  }
+
   /* ── FOOTER ── */
   footer {
     background: var(--deep);
@@ -837,6 +1181,19 @@ import HoneymoonTracker from "../components/HoneymoonTracker"
     .budget-badge {
       grid-area: badge;
       justify-self: start;
+    }
+    .details-fields {
+      grid-template-columns: 1fr;
+    }
+    .subbar {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.6rem;
+      padding: 0 1.2rem 0.75rem;
+    }
+    .agenda-row {
+      grid-template-columns: auto 70px 1fr;
+      gap: 0.6rem;
     }
   }
 </style>

--- a/src/pages/honeymoon.astro
+++ b/src/pages/honeymoon.astro
@@ -1,0 +1,842 @@
+---
+import HoneymoonTracker from "../components/HoneymoonTracker"
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Our Honeymoon — August 2026</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400&family=Jost:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <HoneymoonTracker client:only="react" />
+    <noscript>
+      <p style="padding:2rem;font-family:sans-serif;text-align:center">
+        This honeymoon tracker needs JavaScript enabled.
+      </p>
+    </noscript>
+  </body>
+</html>
+
+<style is:global>
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  :root {
+    --cream: #f5f0e8;
+    --sand: #e8dcc8;
+    --warm: #c9a96e;
+    --terracotta: #b5623a;
+    --deep: #1a1510;
+    --ink: #2d2418;
+    --sea: #4a7c8e;
+    --sage: #7a8c6e;
+    --muted: #8a7a66;
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    background: var(--cream);
+    color: var(--ink);
+    font-family: "Jost", sans-serif;
+    font-weight: 300;
+    overflow-x: hidden;
+  }
+
+  /* ── HERO ── */
+  .hero {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 4rem 2rem;
+    position: relative;
+    background: var(--deep);
+    overflow: hidden;
+  }
+  .hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(
+        ellipse 80% 50% at 20% 60%,
+        rgba(201, 169, 110, 0.15) 0%,
+        transparent 60%
+      ),
+      radial-gradient(
+        ellipse 60% 70% at 80% 30%,
+        rgba(74, 124, 142, 0.12) 0%,
+        transparent 60%
+      ),
+      radial-gradient(
+        ellipse 100% 80% at 50% 100%,
+        rgba(181, 98, 58, 0.1) 0%,
+        transparent 50%
+      );
+  }
+  .hero-label {
+    font-family: "Jost", sans-serif;
+    font-weight: 400;
+    font-size: 0.7rem;
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    color: var(--warm);
+    margin-bottom: 2rem;
+    opacity: 0;
+    animation: fadeUp 1s 0.3s forwards;
+  }
+  .hero-title {
+    font-family: "Cormorant Garamond", serif;
+    font-weight: 300;
+    font-size: clamp(3.5rem, 10vw, 8rem);
+    line-height: 0.95;
+    color: var(--cream);
+    letter-spacing: -0.02em;
+    opacity: 0;
+    animation: fadeUp 1s 0.6s forwards;
+  }
+  .hero-title em {
+    font-style: italic;
+    color: var(--warm);
+  }
+  .hero-sub {
+    font-family: "Cormorant Garamond", serif;
+    font-style: italic;
+    font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+    color: rgba(245, 240, 232, 0.55);
+    margin-top: 1.5rem;
+    letter-spacing: 0.05em;
+    opacity: 0;
+    animation: fadeUp 1s 0.9s forwards;
+  }
+  .hero-route {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 3rem;
+    opacity: 0;
+    animation: fadeUp 1s 1.2s forwards;
+  }
+  .hero-route-stop {
+    font-size: 0.65rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(245, 240, 232, 0.5);
+    font-weight: 400;
+  }
+  .hero-route-stop.highlight {
+    color: var(--warm);
+  }
+  .hero-route-dot {
+    width: 3px;
+    height: 3px;
+    border-radius: 50%;
+    background: var(--warm);
+    opacity: 0.4;
+  }
+  .scroll-hint {
+    position: absolute;
+    bottom: 2.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 0;
+    animation: fadeUp 1s 1.8s forwards;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .scroll-hint span {
+    font-size: 0.6rem;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: rgba(245, 240, 232, 0.3);
+  }
+  .scroll-line {
+    width: 1px;
+    height: 40px;
+    background: linear-gradient(to bottom, var(--warm), transparent);
+    animation: scrollPulse 2s 2s infinite;
+  }
+
+  /* ── OVERVIEW STRIP ── */
+  .overview {
+    background: var(--warm);
+    padding: 1.5rem 2rem;
+    display: flex;
+    justify-content: center;
+    gap: clamp(1.5rem, 4vw, 4rem);
+    flex-wrap: wrap;
+  }
+  .overview-stat {
+    text-align: center;
+  }
+  .overview-stat .num {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 2rem;
+    font-weight: 300;
+    color: var(--deep);
+    line-height: 1;
+  }
+  .overview-stat .label {
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(26, 21, 16, 0.6);
+    margin-top: 0.25rem;
+  }
+
+  /* ── STICKY CONTROL BAR ── */
+  .ctrlbar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: rgba(245, 240, 232, 0.92);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--sand);
+  }
+  .ctrlbar-inner {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 0.75rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+  .tabs {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .tab {
+    font-family: "Jost", sans-serif;
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-weight: 500;
+    padding: 0.45rem 0.9rem;
+    border: 1px solid var(--sand);
+    background: transparent;
+    color: var(--muted);
+    border-radius: 2rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+  .tab:hover {
+    color: var(--ink);
+  }
+  .tab.active {
+    background: var(--ink);
+    color: var(--cream);
+    border-color: var(--ink);
+  }
+  .progress {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .progress-track {
+    width: 90px;
+    height: 5px;
+    background: var(--sand);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .progress-fill {
+    height: 100%;
+    background: var(--terracotta);
+    border-radius: 3px;
+    transition: width 0.4s ease;
+  }
+  .progress-text {
+    font-size: 0.6rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  /* ── MAIN CONTENT ── */
+  .container {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 0 2rem;
+  }
+
+  /* ── DESTINATION SECTIONS ── */
+  .destination {
+    padding: 5rem 0 2rem;
+    opacity: 0;
+    transform: translateY(30px);
+    transition:
+      opacity 0.7s ease,
+      transform 0.7s ease;
+  }
+  .destination.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .dest-header {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 2rem;
+    align-items: start;
+    margin-bottom: 2.5rem;
+  }
+  .dest-number {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 5rem;
+    font-weight: 300;
+    line-height: 1;
+    color: var(--sand);
+    letter-spacing: -0.04em;
+    user-select: none;
+  }
+  .dest-meta {
+    padding-top: 0.5rem;
+  }
+  .dest-tag {
+    font-size: 0.6rem;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--warm);
+    font-weight: 500;
+    margin-bottom: 0.4rem;
+  }
+  .dest-name {
+    font-family: "Cormorant Garamond", serif;
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    font-weight: 300;
+    line-height: 1.05;
+    color: var(--ink);
+    letter-spacing: -0.02em;
+  }
+  .dest-name em {
+    font-style: italic;
+    color: var(--terracotta);
+  }
+  .dest-dates {
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    margin-top: 0.5rem;
+    font-weight: 400;
+  }
+
+  /* ── DAY CARDS ── */
+  .days {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border-left: 1px solid var(--sand);
+    margin-left: 1rem;
+    padding-left: 0;
+  }
+  .day-card {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 1.5rem;
+    padding: 1.5rem 0 1.5rem 2rem;
+    position: relative;
+    transition: opacity 0.3s ease;
+  }
+  .day-card::before {
+    content: "";
+    position: absolute;
+    left: -5px;
+    top: 2rem;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--cream);
+    border: 2px solid var(--warm);
+    transition: background 0.2s ease;
+  }
+  .day-card.done::before {
+    background: var(--terracotta);
+    border-color: var(--terracotta);
+  }
+  .day-card.done .day-desc {
+    opacity: 0.55;
+  }
+  .day-label {
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+    padding-top: 0.15rem;
+    line-height: 1.4;
+  }
+  .day-label strong {
+    display: block;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 1.3rem;
+    font-weight: 400;
+    color: var(--ink);
+    letter-spacing: 0;
+    line-height: 1;
+    margin-bottom: 0.2rem;
+  }
+  .day-content {
+    padding-bottom: 0.5rem;
+  }
+  .day-check {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    margin-bottom: 0.5rem;
+  }
+  .day-check-box {
+    flex: 0 0 auto;
+    width: 18px;
+    height: 18px;
+    border: 1.5px solid var(--warm);
+    border-radius: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    color: var(--cream);
+    transition: all 0.2s ease;
+  }
+  .day-check.checked .day-check-box {
+    background: var(--terracotta);
+    border-color: var(--terracotta);
+  }
+  .day-title {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 1.2rem;
+    font-weight: 500;
+    color: var(--ink);
+  }
+  .day-check.checked .day-title {
+    text-decoration: line-through;
+    text-decoration-color: var(--warm);
+    color: var(--muted);
+  }
+  .day-desc {
+    font-size: 0.82rem;
+    line-height: 1.75;
+    color: var(--muted);
+    font-weight: 300;
+  }
+  .day-highlights {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .tag {
+    font-size: 0.6rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0.3rem 0.7rem;
+    border-radius: 2rem;
+    font-weight: 500;
+  }
+  .tag-transport {
+    background: rgba(74, 124, 142, 0.12);
+    color: var(--sea);
+  }
+  .tag-stay {
+    background: rgba(122, 140, 110, 0.15);
+    color: var(--sage);
+  }
+  .tag-activity {
+    background: rgba(201, 169, 110, 0.2);
+    color: #7a5e28;
+  }
+  .tag-food {
+    background: rgba(181, 98, 58, 0.12);
+    color: var(--terracotta);
+  }
+  .tag-booked {
+    background: rgba(26, 21, 16, 0.07);
+    color: var(--ink);
+  }
+  .tag-map {
+    background: rgba(26, 21, 16, 0.06);
+    color: var(--ink);
+    text-decoration: none;
+    border: 1px solid var(--sand);
+    transition: all 0.2s ease;
+  }
+  .tag-map:hover {
+    background: var(--ink);
+    color: var(--cream);
+    border-color: var(--ink);
+  }
+
+  /* ── NOTES ── */
+  .note-row {
+    margin-top: 0.75rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+  .note-toggle {
+    font-family: "Jost", sans-serif;
+    font-size: 0.6rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 500;
+    color: var(--sea);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+  }
+  .note-toggle:hover {
+    color: var(--terracotta);
+  }
+  .note-preview {
+    font-size: 0.75rem;
+    color: var(--muted);
+    font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+  .note-input {
+    margin-top: 0.6rem;
+    width: 100%;
+    min-height: 70px;
+    resize: vertical;
+    font-family: "Jost", sans-serif;
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: var(--ink);
+    background: rgba(255, 255, 255, 0.5);
+    border: 1px solid var(--sand);
+    border-radius: 8px;
+    padding: 0.7rem 0.9rem;
+  }
+  .note-input:focus {
+    outline: none;
+    border-color: var(--warm);
+  }
+
+  /* ── TRANSIT ROWS ── */
+  .transit {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.25rem 2rem;
+    background: var(--deep);
+    margin: 1rem -2rem;
+    position: relative;
+    overflow: hidden;
+  }
+  .transit::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      rgba(201, 169, 110, 0.05) 0%,
+      transparent 50%
+    );
+  }
+  .transit-icon {
+    font-size: 1.1rem;
+    opacity: 0.7;
+  }
+  .transit-text {
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(245, 240, 232, 0.55);
+    font-weight: 400;
+    flex: 1;
+  }
+  .transit-text strong {
+    color: var(--warm);
+    font-weight: 500;
+  }
+  .transit-badge {
+    font-size: 0.58rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid rgba(201, 169, 110, 0.3);
+    color: var(--warm);
+    border-radius: 2rem;
+    white-space: nowrap;
+  }
+  .transit-badge.booked {
+    border-color: rgba(122, 140, 110, 0.5);
+    color: var(--sage);
+  }
+
+  /* ── DIVIDER ── */
+  .section-divider {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--sand), transparent);
+    margin: 3rem 0;
+  }
+
+  /* ── LIST SECTIONS (To-Do / Budget) ── */
+  .list-section {
+    padding: 3.5rem 0 1rem;
+    opacity: 0;
+    animation: fadeUp 0.6s forwards;
+  }
+  .list-head {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 2rem;
+    font-weight: 300;
+    color: var(--ink);
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--sand);
+    padding-bottom: 0.6rem;
+    margin-bottom: 1.2rem;
+  }
+  .list-count {
+    font-family: "Jost", sans-serif;
+    font-size: 0.6rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+  }
+  .checklist {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .check-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.7rem 0.4rem;
+    cursor: pointer;
+    border-radius: 8px;
+    transition: background 0.15s ease;
+  }
+  .check-row:hover {
+    background: rgba(201, 169, 110, 0.08);
+  }
+  .check-row input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  .check-box {
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+    border: 1.5px solid var(--warm);
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    color: var(--cream);
+    transition: all 0.2s ease;
+  }
+  .check-row.checked .check-box {
+    background: var(--terracotta);
+    border-color: var(--terracotta);
+  }
+  .check-label {
+    font-size: 0.9rem;
+    color: var(--ink);
+  }
+  .check-row.checked .check-label {
+    text-decoration: line-through;
+    text-decoration-color: var(--warm);
+    color: var(--muted);
+  }
+
+  /* ── BUDGET ── */
+  .budget {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+  }
+  .budget-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.8rem 0.4rem;
+    border-bottom: 1px solid var(--sand);
+  }
+  .budget-label {
+    font-size: 0.85rem;
+    color: var(--ink);
+  }
+  .budget-amt {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 1.1rem;
+    color: var(--ink);
+    white-space: nowrap;
+  }
+  .budget-badge {
+    font-size: 0.55rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    padding: 0.2rem 0.55rem;
+    border-radius: 2rem;
+    border: 1px solid var(--sand);
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .budget-badge.booked {
+    border-color: rgba(122, 140, 110, 0.5);
+    color: var(--sage);
+  }
+  .budget-totals {
+    display: flex;
+    gap: 2.5rem;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+    padding: 1.2rem 0.4rem;
+  }
+  .budget-totals > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .budget-total-label {
+    font-size: 0.6rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+  }
+  .budget-total-num {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 1.8rem;
+    color: var(--terracotta);
+    line-height: 1;
+  }
+  .budget-note {
+    font-size: 0.75rem;
+    color: var(--muted);
+    margin-top: 0.5rem;
+    line-height: 1.6;
+  }
+  .budget-note code {
+    font-family: monospace;
+    background: rgba(26, 21, 16, 0.06);
+    padding: 0.1rem 0.3rem;
+    border-radius: 4px;
+  }
+
+  /* ── FOOTER ── */
+  footer {
+    background: var(--deep);
+    padding: 4rem 2rem;
+    text-align: center;
+    margin-top: 3rem;
+  }
+  footer .footer-title {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 2rem;
+    font-style: italic;
+    color: var(--warm);
+    margin-bottom: 1rem;
+  }
+  footer p {
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    color: rgba(245, 240, 232, 0.3);
+    text-transform: uppercase;
+  }
+
+  /* ── ANIMATIONS ── */
+  @keyframes fadeUp {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @keyframes scrollPulse {
+    0%,
+    100% {
+      opacity: 0.4;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
+  /* ── MOBILE ── */
+  @media (max-width: 600px) {
+    .dest-header {
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+    }
+    .dest-number {
+      font-size: 3rem;
+    }
+    .day-card {
+      grid-template-columns: 60px 1fr;
+      gap: 1rem;
+    }
+    .transit {
+      margin: 1rem -2rem;
+      padding: 1rem 1.5rem;
+      flex-wrap: wrap;
+    }
+    .ctrlbar-inner {
+      padding: 0.6rem 1.2rem;
+    }
+    .budget-row {
+      grid-template-columns: 1fr auto;
+      grid-template-areas: "label amt" "badge badge";
+      row-gap: 0.3rem;
+    }
+    .budget-label {
+      grid-area: label;
+    }
+    .budget-amt {
+      grid-area: amt;
+    }
+    .budget-badge {
+      grid-area: badge;
+      justify-self: start;
+    }
+  }
+</style>

--- a/src/pages/honeymoon.astro
+++ b/src/pages/honeymoon.astro
@@ -986,6 +986,143 @@ import HoneymoonTracker from "../components/HoneymoonTracker"
     line-height: 1.6;
   }
 
+  /* ── HOUR-BY-HOUR TIMELINE ── */
+  .timeline-wrap {
+    margin-top: 0.85rem;
+  }
+  .timeline-toggle {
+    color: var(--warm);
+    border-color: rgba(201, 169, 110, 0.4);
+  }
+  .timeline {
+    list-style: none;
+    margin: 0.9rem 0 0.3rem;
+    padding: 0;
+    position: relative;
+  }
+  .tl-row {
+    display: grid;
+    grid-template-columns: 58px 14px 1fr;
+    gap: 0.6rem;
+    align-items: start;
+    padding: 0 0 1rem 0;
+    position: relative;
+  }
+  /* connector line through the dots */
+  .tl-row::before {
+    content: "";
+    position: absolute;
+    left: 64px;
+    top: 1.1rem;
+    bottom: -0.1rem;
+    width: 1px;
+    background: var(--sand);
+  }
+  .tl-row:last-child::before {
+    display: none;
+  }
+  .tl-time {
+    font-family: "Cormorant Garamond", serif;
+    font-size: 0.95rem;
+    color: var(--ink);
+    text-align: right;
+    line-height: 1.3;
+    white-space: nowrap;
+  }
+  .tl-dot {
+    width: 9px;
+    height: 9px;
+    margin-top: 0.45rem;
+    border-radius: 50%;
+    background: var(--cream);
+    border: 2px solid var(--warm);
+    z-index: 1;
+    justify-self: center;
+  }
+  /* kind-coded dots */
+  .tl-travel .tl-dot {
+    border-color: var(--sea);
+  }
+  .tl-meal .tl-dot {
+    border-color: var(--terracotta);
+    background: var(--terracotta);
+  }
+  .tl-activity .tl-dot {
+    border-color: #7a5e28;
+    background: rgba(201, 169, 110, 0.5);
+  }
+  .tl-checkin .tl-dot {
+    border-color: var(--sage);
+  }
+  .tl-downtime .tl-dot {
+    border-color: var(--muted);
+    background: transparent;
+  }
+  .tl-body {
+    padding-top: 0.05rem;
+  }
+  .tl-title {
+    font-size: 0.85rem;
+    color: var(--ink);
+    line-height: 1.4;
+  }
+  .tl-link {
+    color: var(--ink);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--warm);
+  }
+  .tl-link:hover {
+    color: var(--terracotta);
+  }
+  .tl-detail {
+    font-size: 0.76rem;
+    line-height: 1.6;
+    color: var(--muted);
+    margin-top: 0.2rem;
+  }
+  .tl-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.4rem;
+  }
+  .tl-chip {
+    font-size: 0.56rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 500;
+    padding: 0.18rem 0.5rem;
+    border-radius: 2rem;
+    background: rgba(26, 21, 16, 0.06);
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .tl-chip-travel {
+    background: rgba(74, 124, 142, 0.12);
+    color: var(--sea);
+  }
+  .tl-chip-booked {
+    background: rgba(122, 140, 110, 0.15);
+    color: var(--sage);
+  }
+  .tl-chip-to-book {
+    background: rgba(181, 98, 58, 0.12);
+    color: var(--terracotta);
+  }
+  .tl-chip-walk-in {
+    background: rgba(201, 169, 110, 0.2);
+    color: #7a5e28;
+  }
+  @media (max-width: 600px) {
+    .tl-row {
+      grid-template-columns: 50px 12px 1fr;
+      gap: 0.5rem;
+    }
+    .tl-row::before {
+      left: 55px;
+    }
+  }
+
   /* ── AGENDA VIEW ── */
   .agenda-stop {
     padding-top: 2rem;


### PR DESCRIPTION
## What

An unlisted, interactive honeymoon itinerary tracker at **`/honeymoon`** for Brendan & Scott's Aug–Sep 2026 trip. Built on the existing Astro + React-island stack, styled in a standalone cream/serif aesthetic separate from the main site.

Started from the `honeymoon-itinerary.html` draft; restructured into a data-driven page.

## How it works

- **Single source of truth:** `src/data/honeymoon.ts` — edit this one file to update everything (stops, days, flights/ferries, maps spots, checklist, budget). Inline editing guide at the top.
- **One React island** (`HoneymoonTracker.jsx`, `client:only="react"`) renders the design and owns all state, persisted to `localStorage` (`honeymoon-tracker-v1`).
- **Thin page wrapper** (`honeymoon.astro`) — self-contained document with the fonts + all design CSS.

## Features

- **Itinerary** — stop-by-stop day cards you can ✓ check off (with a progress bar), per-day editable **notes**, transit rows (flights/ferries) with booked/to-book badges, and 📍 **Google/Apple Maps links** for every spot (London shops, beach clubs, Sarakiniko, Èze, Arthur Ashe, etc.)
- **To-Do** — To Book / Before We Go / Packing checklists
- **Budget** — per-item costs with booked/open badges + running totals

## Privacy

- `<meta name="robots" content="noindex, nofollow">`, not in site nav, excluded from `sitemap` (filter in `astro.config.mjs`). Anyone with the URL can view (no auth on a static Netlify site).

## ⚠️ Data is placeholder — needs your real booked values

Filled real flight numbers from your notes where known (BA 296, BA 668, A3 690, La Compagnie B0 200). Still **TBD / marked to-book**: ferry times, all 6 hotels, the NYC→ORD return flight + date, exact times. Everything's editable in `src/data/honeymoon.ts`.

## Test

- `npm run build` passes; `/honeymoon/index.html` generated, confirmed `noindex` + sitemap exclusion.
- Check the Netlify **Deploy Preview** for the live page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)