### PR TITLE
chore(ci): ignore eslint major bumps until eslint-plugin-react supports v10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 10
+    ignore:
+      # eslint 10 blocked: eslint-plugin-react (even latest) peer-pins ^9.7 and
+      # crashes at runtime on v10 — see jsx-eslint/eslint-plugin-react#3977.
+      # Remove this once that issue is resolved.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group all Astro + integrations together including majors — they share
       # peer dep requirements and must be upgraded in a single PR


### PR DESCRIPTION
Closes the loop on #209: eslint-plugin-react (even latest 7.37.5) peer-pins eslint `^9.7` and crashes at runtime on ESLint 10 (jsx-eslint/eslint-plugin-react#3977). This ignore rule keeps Dependabot from re-opening the failing v10 bump on every eslint release; 9.x minors/patches still flow through the dev-dependencies group.

Remove the ignore once #3977 is resolved upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)