### PR TITLE
feat(cards): 2-player card game library with scorekeeper + leaderboard

### DIFF
--- a/src/components/CardGames.jsx
+++ b/src/components/CardGames.jsx
@@ -1,0 +1,591 @@
+import { useEffect, useMemo, useState } from "react"
+import { cardGames } from "../data/cardGames"
+
+// Offline-first, fully client-side card-game reference + scorekeeper +
+// leaderboard. Mirrors the site's localStorage pattern (hydrate on mount,
+// persist on every change, JSON.parse guarded by try/catch). No network calls.
+
+const STORAGE_KEY = "cards-tracker-v1"
+
+const DEFAULT_STATE = {
+  players: { a: "Brendan", b: "Scott" },
+  // leaderboard[gameId] = { a: winsForPlayerA, b: winsForPlayerB, played }
+  leaderboard: {},
+}
+
+function loadState() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return DEFAULT_STATE
+    const parsed = JSON.parse(stored)
+    return {
+      players: {
+        a: parsed?.players?.a || DEFAULT_STATE.players.a,
+        b: parsed?.players?.b || DEFAULT_STATE.players.b,
+      },
+      leaderboard:
+        parsed && typeof parsed.leaderboard === "object" && parsed.leaderboard
+          ? parsed.leaderboard
+          : {},
+    }
+  } catch {
+    return DEFAULT_STATE
+  }
+}
+
+function saveState(state) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // storage unavailable — state just isn't persisted this session
+  }
+}
+
+// --- small UI helpers --------------------------------------------------------
+
+const TAG_STYLES = {
+  easy: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  medium: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+  quick: "bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-200",
+  long: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+}
+
+function Tag({ label }) {
+  const cls =
+    TAG_STYLES[label] ||
+    "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+  return (
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}>
+      {label}
+    </span>
+  )
+}
+
+function Section({ title, children }) {
+  return (
+    <div className="mt-4">
+      <h4 className="text-sm font-bold tracking-wide text-red-700 uppercase dark:text-red-400">
+        {title}
+      </h4>
+      <div className="mt-1.5 text-gray-900 dark:text-gray-100">{children}</div>
+    </div>
+  )
+}
+
+// --- scorekeeper -------------------------------------------------------------
+
+function Scorekeeper({ game, players, onFinish, onCancel }) {
+  const { scoringType, target, scoringNotes } = game.scoring
+  const isTargeted =
+    scoringType === "first-to-target" || scoringType === "low-score"
+  const [scores, setScores] = useState({ a: 0, b: 0 })
+  const [declared, setDeclared] = useState(null) // "a" | "b" | null
+
+  // For targeted games, auto-suggest a winner once a total crosses the target.
+  const autoWinner = useMemo(() => {
+    if (declared) return declared
+    if (!isTargeted || target == null) return null
+    if (scoringType === "first-to-target") {
+      if (scores.a >= target && scores.a > scores.b) return "a"
+      if (scores.b >= target && scores.b > scores.a) return "b"
+    }
+    // low-score games end by deal count elsewhere; no auto-cross here.
+    return null
+  }, [declared, isTargeted, target, scoringType, scores])
+
+  const winner = declared || autoWinner
+
+  function bump(key, delta) {
+    setScores(prev => ({ ...prev, [key]: prev[key] + delta }))
+  }
+
+  // single-winner: no running totals, just pick who won.
+  if (scoringType === "single-winner") {
+    return (
+      <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-800">
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {scoringNotes}
+        </p>
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          {["a", "b"].map(key => (
+            <button
+              key={key}
+              onClick={() => onFinish(key)}
+              className="min-h-14 rounded-xl bg-green-600 px-4 py-3 text-lg font-bold text-white active:scale-95"
+            >
+              {players[key]} won
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={onCancel}
+          className="mt-3 w-full rounded-lg px-4 py-2 text-sm text-gray-500 hover:underline dark:text-gray-400"
+        >
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  const lowerWins = scoringType === "low-score"
+  const targetLabel =
+    scoringType === "first-to-target"
+      ? `First to ${target} wins`
+      : scoringType === "low-score"
+        ? `Lowest total over ${target} deals wins`
+        : "Highest total wins"
+
+  return (
+    <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-800">
+      <p className="text-sm text-gray-700 dark:text-gray-300">{scoringNotes}</p>
+      <p className="mt-1 text-xs font-semibold text-red-700 dark:text-red-400">
+        {targetLabel}
+      </p>
+
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        {["a", "b"].map(key => (
+          <div
+            key={key}
+            className={`rounded-xl border p-3 text-center ${
+              winner === key
+                ? "border-green-500 bg-green-50 dark:border-green-500 dark:bg-green-900/30"
+                : "border-gray-200 bg-white dark:border-gray-600 dark:bg-gray-700"
+            }`}
+          >
+            <div className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+              {players[key]}
+            </div>
+            <div className="my-2 text-4xl font-bold text-gray-900 tabular-nums dark:text-white">
+              {scores[key]}
+            </div>
+            <div className="grid grid-cols-3 gap-1.5">
+              <button
+                onClick={() => bump(key, -1)}
+                className="min-h-11 rounded-lg bg-gray-200 text-lg font-bold text-gray-800 active:scale-95 dark:bg-gray-600 dark:text-gray-100"
+                aria-label={`Subtract 1 from ${players[key]}`}
+              >
+                −1
+              </button>
+              <button
+                onClick={() => bump(key, 5)}
+                className="min-h-11 rounded-lg bg-gray-200 text-sm font-bold text-gray-800 active:scale-95 dark:bg-gray-600 dark:text-gray-100"
+                aria-label={`Add 5 to ${players[key]}`}
+              >
+                +5
+              </button>
+              <button
+                onClick={() => bump(key, 1)}
+                className="min-h-11 rounded-lg bg-blue-600 text-lg font-bold text-white active:scale-95"
+                aria-label={`Add 1 to ${players[key]}`}
+              >
+                +1
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {winner && (
+        <div className="mt-4 rounded-lg bg-green-100 p-3 text-center text-sm font-bold text-green-800 dark:bg-green-900 dark:text-green-100">
+          {players[winner]} is winning
+          {lowerWins ? " (lowest score)" : ""}!
+        </div>
+      )}
+
+      <div className="mt-4 space-y-2">
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            onClick={() => setDeclared("a")}
+            className="min-h-12 rounded-lg bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-800 active:scale-95 dark:bg-gray-600 dark:text-gray-100"
+          >
+            Declare {players.a}
+          </button>
+          <button
+            onClick={() => setDeclared("b")}
+            className="min-h-12 rounded-lg bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-800 active:scale-95 dark:bg-gray-600 dark:text-gray-100"
+          >
+            Declare {players.b}
+          </button>
+        </div>
+        <button
+          disabled={!winner}
+          onClick={() => winner && onFinish(winner)}
+          className="min-h-12 w-full rounded-lg bg-green-600 px-4 py-3 font-bold text-white active:scale-95 disabled:opacity-40"
+        >
+          Record win to leaderboard
+        </button>
+        <button
+          onClick={onCancel}
+          className="w-full rounded-lg px-4 py-2 text-sm text-gray-500 hover:underline dark:text-gray-400"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// --- game detail (accordion body) -------------------------------------------
+
+function GameDetail({ game, players, onRecordWin }) {
+  const [scoring, setScoring] = useState(false)
+
+  return (
+    <div className="border-t border-gray-200 px-4 pb-4 dark:border-gray-700">
+      <Section title="Setup">
+        <ol className="list-decimal space-y-1 pl-5 text-sm">
+          {game.setup.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ol>
+      </Section>
+
+      <Section title="How to play">
+        <ol className="list-decimal space-y-1 pl-5 text-sm">
+          {game.howToPlay.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ol>
+      </Section>
+
+      <Section title="How to win">
+        <p className="text-sm">{game.howToWin}</p>
+      </Section>
+
+      <Section title="Variants">
+        <ul className="space-y-2 text-sm">
+          {game.variants.map((v, i) => (
+            <li key={i}>
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {v.name}:
+              </span>{" "}
+              {v.description}
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section title="Scoring">
+        <p className="text-sm">{game.scoring.scoringNotes}</p>
+      </Section>
+
+      {scoring ? (
+        <Scorekeeper
+          game={game}
+          players={players}
+          onCancel={() => setScoring(false)}
+          onFinish={winnerKey => {
+            onRecordWin(game.id, winnerKey)
+            setScoring(false)
+          }}
+        />
+      ) : (
+        <button
+          onClick={() => setScoring(true)}
+          className="mt-5 min-h-12 w-full rounded-xl bg-red-700 px-4 py-3 font-bold text-white hover:bg-red-800 active:scale-95"
+        >
+          Start scoring this game
+        </button>
+      )}
+    </div>
+  )
+}
+
+// --- leaderboard -------------------------------------------------------------
+
+function Leaderboard({ players, leaderboard, onClear }) {
+  const totals = useMemo(() => {
+    let a = 0
+    let b = 0
+    let played = 0
+    for (const id of Object.keys(leaderboard)) {
+      const row = leaderboard[id]
+      a += row.a || 0
+      b += row.b || 0
+      played += row.played || 0
+    }
+    return { a, b, played }
+  }, [leaderboard])
+
+  const rows = useMemo(
+    () =>
+      cardGames
+        .map(g => ({ game: g, row: leaderboard[g.id] }))
+        .filter(r => r.row && r.row.played > 0),
+    [leaderboard],
+  )
+
+  return (
+    <div className="mt-6">
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-gray-800">
+          <div className="truncate text-sm text-gray-500 dark:text-gray-400">
+            {players.a}
+          </div>
+          <div className="text-3xl font-bold text-gray-900 tabular-nums dark:text-white">
+            {totals.a}
+          </div>
+          <div className="text-xs text-gray-400">wins</div>
+        </div>
+        <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-gray-800">
+          <div className="text-sm text-gray-500 dark:text-gray-400">Played</div>
+          <div className="text-3xl font-bold text-gray-900 tabular-nums dark:text-white">
+            {totals.played}
+          </div>
+          <div className="text-xs text-gray-400">games</div>
+        </div>
+        <div className="rounded-xl bg-white p-4 shadow-sm dark:bg-gray-800">
+          <div className="truncate text-sm text-gray-500 dark:text-gray-400">
+            {players.b}
+          </div>
+          <div className="text-3xl font-bold text-gray-900 tabular-nums dark:text-white">
+            {totals.b}
+          </div>
+          <div className="text-xs text-gray-400">wins</div>
+        </div>
+      </div>
+
+      {rows.length > 0 ? (
+        <div className="mt-4 overflow-hidden rounded-xl bg-white shadow-sm dark:bg-gray-800">
+          {rows.map(({ game, row }) => (
+            <div
+              key={game.id}
+              className="flex items-center justify-between border-b border-gray-100 px-4 py-2.5 last:border-b-0 dark:border-gray-700"
+            >
+              <span className="text-sm font-medium text-gray-900 dark:text-white">
+                {game.name}
+              </span>
+              <span className="text-sm text-gray-600 tabular-nums dark:text-gray-300">
+                {row.a || 0}
+                <span className="mx-1 text-gray-400">–</span>
+                {row.b || 0}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
+          No games recorded yet. Finish a game to fill the board.
+        </p>
+      )}
+
+      {totals.played > 0 && (
+        <button
+          onClick={onClear}
+          className="mt-4 w-full rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-700 active:scale-95 dark:border-red-800 dark:text-red-400"
+        >
+          Reset leaderboard
+        </button>
+      )}
+    </div>
+  )
+}
+
+// --- root --------------------------------------------------------------------
+
+const CardGames = () => {
+  const [hydrated, setHydrated] = useState(false)
+  const [state, setState] = useState(DEFAULT_STATE)
+  const [tab, setTab] = useState("library") // library | players | board
+  const [openId, setOpenId] = useState(null)
+  const [filter, setFilter] = useState("all") // all | quick | strategic
+
+  // Hydrate from localStorage once on mount.
+  useEffect(() => {
+    setState(loadState())
+    setHydrated(true)
+  }, [])
+
+  // Persist on every change, but only after the first hydrate so we don't
+  // clobber stored state with defaults on the initial render.
+  useEffect(() => {
+    if (!hydrated) return
+    saveState(state)
+  }, [state, hydrated])
+
+  const { players, leaderboard } = state
+
+  function setPlayerName(key, value) {
+    setState(prev => ({
+      ...prev,
+      players: { ...prev.players, [key]: value },
+    }))
+  }
+
+  function recordWin(gameId, winnerKey) {
+    setState(prev => {
+      const row = prev.leaderboard[gameId] || { a: 0, b: 0, played: 0 }
+      return {
+        ...prev,
+        leaderboard: {
+          ...prev.leaderboard,
+          [gameId]: {
+            a: row.a + (winnerKey === "a" ? 1 : 0),
+            b: row.b + (winnerKey === "b" ? 1 : 0),
+            played: row.played + 1,
+          },
+        },
+      }
+    })
+    setTab("board")
+    setOpenId(null)
+  }
+
+  function clearBoard() {
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm("Reset the whole leaderboard? This can't be undone.")
+    ) {
+      return
+    }
+    setState(prev => ({ ...prev, leaderboard: {} }))
+  }
+
+  const games = useMemo(() => {
+    if (filter === "quick") {
+      return cardGames.filter(g => g.tags.length === "quick")
+    }
+    if (filter === "strategic") {
+      return cardGames.filter(g => g.tags.vibe === "strategic")
+    }
+    return cardGames
+  }, [filter])
+
+  return (
+    <div className="mx-auto max-w-2xl px-1 pb-20">
+      {/* tabs */}
+      <div className="sticky top-0 z-10 -mx-1 mb-4 grid grid-cols-3 gap-1 bg-white/90 px-1 py-2 backdrop-blur dark:bg-[#032740]/90">
+        {[
+          ["library", "Games"],
+          ["players", "Players"],
+          ["board", "Leaderboard"],
+        ].map(([key, label]) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`min-h-11 rounded-lg px-3 py-2 text-sm font-semibold active:scale-95 ${
+              tab === key
+                ? "bg-red-700 text-white"
+                : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "library" && (
+        <>
+          <div className="mb-4 flex flex-wrap gap-2">
+            {[
+              ["all", "All"],
+              ["quick", "Quick"],
+              ["strategic", "Strategic"],
+            ].map(([key, label]) => (
+              <button
+                key={key}
+                onClick={() => setFilter(key)}
+                className={`min-h-9 rounded-full px-4 py-1.5 text-sm font-medium active:scale-95 ${
+                  filter === key
+                    ? "bg-gray-900 text-white dark:bg-white dark:text-gray-900"
+                    : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          <div className="space-y-3">
+            {games.map(game => {
+              const open = openId === game.id
+              return (
+                <div
+                  key={game.id}
+                  className="overflow-hidden rounded-xl bg-white shadow-sm dark:bg-gray-800"
+                >
+                  <button
+                    onClick={() => setOpenId(open ? null : game.id)}
+                    aria-expanded={open}
+                    className="flex w-full items-start justify-between gap-3 px-4 py-3.5 text-left active:bg-gray-50 dark:active:bg-gray-700"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-lg font-bold text-gray-900 dark:text-white">
+                          {game.name}
+                        </h3>
+                        <span className="text-xs text-gray-400">
+                          {game.players}p
+                        </span>
+                      </div>
+                      <p className="mt-0.5 text-sm text-gray-600 dark:text-gray-300">
+                        {game.hook}
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        <Tag label={game.tags.difficulty} />
+                        <Tag label={game.tags.length} />
+                        <Tag label={game.tags.vibe} />
+                      </div>
+                    </div>
+                    <span
+                      className={`mt-1 shrink-0 text-xl text-gray-400 transition-transform ${
+                        open ? "rotate-180" : ""
+                      }`}
+                      aria-hidden="true"
+                    >
+                      ⌄
+                    </span>
+                  </button>
+                  {open && (
+                    <GameDetail
+                      game={game}
+                      players={players}
+                      onRecordWin={recordWin}
+                    />
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      {tab === "players" && (
+        <div className="rounded-xl bg-white p-5 shadow-sm dark:bg-gray-800">
+          <p className="mb-4 text-sm text-gray-600 dark:text-gray-300">
+            Names are used across the scorekeeper and leaderboard. They save
+            automatically and work offline.
+          </p>
+          {[
+            ["a", "Player 1"],
+            ["b", "Player 2"],
+          ].map(([key, label]) => (
+            <label key={key} className="mb-4 block">
+              <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+                {label}
+              </span>
+              <input
+                type="text"
+                value={players[key]}
+                onChange={e => setPlayerName(key, e.target.value)}
+                className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder={label}
+                autoComplete="off"
+              />
+            </label>
+          ))}
+        </div>
+      )}
+
+      {tab === "board" && (
+        <Leaderboard
+          players={players}
+          leaderboard={leaderboard}
+          onClear={clearBoard}
+        />
+      )}
+    </div>
+  )
+}
+
+export default CardGames

--- a/src/data/cardGames.ts
+++ b/src/data/cardGames.ts
@@ -1,0 +1,419 @@
+// Library of easy 2-player card games playable with one standard 52-card deck.
+// Rules are the widely-accepted standard 2-player versions, kept concise for
+// quick vacation reference. Consumed by src/components/CardGames.jsx.
+
+export type Difficulty = "easy" | "medium"
+export type Length = "quick" | "medium" | "long"
+export type Vibe = "chill" | "fast" | "strategic" | "luck" | "reflex"
+
+// How a game is scored, driving which scorekeeper UI the island shows.
+//  - "first-to-target": accumulate points across rounds, first to hit target wins
+//  - "round-tally":     tally points per round, highest total wins (manual end)
+//  - "low-score":       accumulate points, LOWEST total wins (e.g. Golf)
+//  - "single-winner":   no running score; one player just wins the game
+export type ScoringType =
+  "first-to-target" | "round-tally" | "single-winner" | "low-score"
+
+export interface Variant {
+  name: string
+  description: string
+}
+
+export interface Scoring {
+  scoringType: ScoringType
+  scoringNotes: string
+  // Present for target-based games (first-to-target / low-score).
+  target?: number
+}
+
+export interface CardGame {
+  id: string
+  name: string
+  // One-line hook shown on the collapsed card.
+  hook: string
+  tags: {
+    difficulty: Difficulty
+    length: Length
+    vibe: Vibe
+  }
+  players: "2" | "2+"
+  setup: string[]
+  howToPlay: string[]
+  howToWin: string
+  variants: Variant[]
+  scoring: Scoring
+}
+
+export const cardGames: CardGame[] = [
+  {
+    id: "go-fish",
+    name: "Go Fish",
+    hook: "Beg for cards, collect four-of-a-kind sets.",
+    tags: { difficulty: "easy", length: "quick", vibe: "chill" },
+    players: "2+",
+    setup: [
+      "Deal 7 cards to each player (5 each if more than two play).",
+      "Place the rest face down as the stock (the 'ocean').",
+    ],
+    howToPlay: [
+      "On your turn, ask the other player for a rank you already hold (e.g. 'Got any sevens?').",
+      "If they have cards of that rank, they hand them all over and you go again.",
+      "If they don't, they say 'Go Fish' and you draw the top stock card.",
+      "If you draw the rank you asked for, reveal it and take another turn; otherwise play passes.",
+      "Whenever you collect all four of a rank, lay the set face up in front of you.",
+    ],
+    howToWin:
+      "The player with the most completed four-of-a-kind sets when all 13 sets are made wins.",
+    variants: [
+      {
+        name: "Ask by exact card",
+        description:
+          "Must ask for a specific card (e.g. 'the 7 of hearts') instead of a whole rank — harder.",
+      },
+      {
+        name: "Pairs, not sets",
+        description:
+          "Collect matching pairs instead of full four-of-a-kinds for a faster game.",
+      },
+    ],
+    scoring: {
+      scoringType: "round-tally",
+      scoringNotes:
+        "Score 1 point per completed set of four. There are 13 sets total; most sets wins.",
+    },
+  },
+  {
+    id: "crazy-8s",
+    name: "Crazy 8s",
+    hook: "Match rank or suit; 8s are wild.",
+    tags: { difficulty: "easy", length: "quick", vibe: "chill" },
+    players: "2+",
+    setup: [
+      "Deal 7 cards to each player (5 each with more than two).",
+      "Place the rest face down as the stock; flip the top card face up to start the discard pile.",
+    ],
+    howToPlay: [
+      "On your turn, play a card that matches the suit or rank of the top discard.",
+      "An 8 is wild: play it any time and name the suit the next player must follow.",
+      "If you can't (or won't) play, draw from the stock until you can, then play it.",
+      "If the stock runs out and you can't play, your turn is skipped.",
+      "The first player to get rid of all their cards wins the round.",
+    ],
+    howToWin:
+      "Be the first to empty your hand. For a match, play to a target using penalty points from cards left in hand.",
+    variants: [
+      {
+        name: "Point match to 100",
+        description:
+          "After each round, losers score points for cards left in hand (8=50, face=10, ace=1, others face value). First to 100 loses; lowest total wins overall.",
+      },
+      {
+        name: "Draw-and-pass",
+        description:
+          "If you can't play, draw just one card; if it's still unplayable, pass. Faster, more luck.",
+      },
+    ],
+    scoring: {
+      scoringType: "first-to-target",
+      scoringNotes:
+        "Optional match play: winner of a round scores the penalty value of opponents' leftover cards (8=50, face=10, ace=1, pip=face value). First to the target total wins the match.",
+      target: 100,
+    },
+  },
+  {
+    id: "war",
+    name: "War",
+    hook: "Flip cards; higher card takes both. Pure luck.",
+    tags: { difficulty: "easy", length: "long", vibe: "luck" },
+    players: "2",
+    setup: [
+      "Deal the whole deck evenly, 26 cards each, face down as a personal stack.",
+      "No looking at your cards.",
+    ],
+    howToPlay: [
+      "Both players flip their top card at the same time.",
+      "The higher card wins both cards, added to the bottom of the winner's stack (aces high).",
+      "On a tie it's WAR: each player deals three cards face down, then one face up. Higher face-up card takes all cards in play.",
+      "If a war ties again, repeat until someone wins the pile.",
+    ],
+    howToWin: "Win all 52 cards. The player who runs out of cards loses.",
+    variants: [
+      {
+        name: "Fewer war cards",
+        description:
+          "Put down one card face down (not three) on a war to make games much shorter.",
+      },
+      {
+        name: "Casino War",
+        description:
+          "On a tie you may 'surrender' half your stake or 'go to war' — adds a betting element.",
+      },
+    ],
+    scoring: {
+      scoringType: "single-winner",
+      scoringNotes:
+        "No points — whoever collects all the cards wins the game. Tap the winner when someone runs out.",
+    },
+  },
+  {
+    id: "speed",
+    name: "Speed (Spit)",
+    hook: "Race, no turns — dump cards fastest to win.",
+    tags: { difficulty: "medium", length: "quick", vibe: "fast" },
+    players: "2",
+    setup: [
+      "Deal 20 cards to each player; each makes a face-down draw pile of 15 and a 5-card hand.",
+      "In the center place two face-down 'spit' piles (one each), and set aside two extra cards as the center stacks.",
+      "Flip the two center cards face up at the same time to start.",
+    ],
+    howToPlay: [
+      "There are no turns — both players play at once, as fast as they can.",
+      "Play any hand card that is one rank higher OR one lower than a center pile's top card (aces wrap to kings).",
+      "Refill your hand back up to five from your draw pile whenever you can (max five in hand).",
+      "If both players are stuck, each flips one new center card from their spit pile at the same time and play resumes.",
+      "When you empty your hand and draw pile, slap the smaller center pile to claim it.",
+    ],
+    howToWin:
+      "Be the first to get rid of all your cards (hand and draw pile). Fewest cards after the last 'spit' wins.",
+    variants: [
+      {
+        name: "Nertz-lite",
+        description:
+          "Play to a target over several rounds; loser of each round carries a penalty.",
+      },
+      {
+        name: "Slower start",
+        description:
+          "Deal only 15 cards each for a quicker, gentler round while learning.",
+      },
+    ],
+    scoring: {
+      scoringType: "single-winner",
+      scoringNotes:
+        "First to shed all cards wins the round. Tap the winner; best-of-N is up to you.",
+    },
+  },
+  {
+    id: "egyptian-rat-screw",
+    name: "Egyptian Rat Screw",
+    hook: "Slap-the-pile speed game with brutal penalties.",
+    tags: { difficulty: "medium", length: "medium", vibe: "reflex" },
+    players: "2+",
+    setup: [
+      "Deal the whole deck evenly, face down. Players don't look at their cards.",
+    ],
+    howToPlay: [
+      "Take turns flipping your top card onto a central pile.",
+      "Slap the pile to win it whenever a valid slap pattern appears: a double (two same rank in a row), or a sandwich (same rank with one card between).",
+      "The first hand to slap a valid pile takes the whole pile to the bottom of their stack.",
+      "If you flip a face card or ace, the next player owes 'pays': 4 cards for an ace, 3 for a king, 2 for a queen, 1 for a jack.",
+      "If they flip another face/ace during the payment, the debt passes to the next player; otherwise the person who played the face card takes the pile.",
+      "Slapping a pile with no valid pattern costs you a card, placed face up under the pile ('burn').",
+    ],
+    howToWin:
+      "Collect all 52 cards. A player with no cards is out but may slap back in.",
+    variants: [
+      {
+        name: "More slap rules",
+        description:
+          "Add tops-and-bottoms, four-in-a-row, or adding-to-ten as extra valid slaps.",
+      },
+      {
+        name: "No burn",
+        description:
+          "A false slap just returns the card with no penalty — friendlier for kids.",
+      },
+    ],
+    scoring: {
+      scoringType: "single-winner",
+      scoringNotes:
+        "No points — winner is whoever ends up holding all the cards. Tap the winner.",
+    },
+  },
+  {
+    id: "snap",
+    name: "Snap",
+    hook: "Shout 'Snap!' on matching cards — fastest wins the pile.",
+    tags: { difficulty: "easy", length: "quick", vibe: "reflex" },
+    players: "2+",
+    setup: [
+      "Deal the entire deck evenly, face down. Don't look at your cards.",
+    ],
+    howToPlay: [
+      "Take turns flipping your top card into a shared central face-up pile (or one pile each).",
+      "When two consecutive top cards match in rank, the first to shout 'Snap!' takes the whole pile.",
+      "A wrong 'Snap!' means you give one card to each opponent as a penalty.",
+      "Won piles go to the bottom of your stack.",
+    ],
+    howToWin:
+      "Collect all the cards. When a player runs out they're out; last player standing wins.",
+    variants: [
+      {
+        name: "Two-pile Snap Pool",
+        description:
+          "Each player flips to their own pile; snap when the two exposed piles match.",
+      },
+      {
+        name: "Snap Pool",
+        description:
+          "Match against a central pool pile instead of the previous card — more chances to snap.",
+      },
+    ],
+    scoring: {
+      scoringType: "single-winner",
+      scoringNotes:
+        "No points — the player who wins all the cards wins. Tap the winner.",
+    },
+  },
+  {
+    id: "gin-rummy",
+    name: "Gin Rummy",
+    hook: "Build runs and sets, knock to score. The classic 2-player rummy.",
+    tags: { difficulty: "medium", length: "medium", vibe: "strategic" },
+    players: "2",
+    setup: [
+      "Deal 10 cards to each player.",
+      "Place the rest face down as the stock; flip the top card face up to start the discard pile.",
+    ],
+    howToPlay: [
+      "On your turn, draw the top stock card or the top discard, then discard one card.",
+      "Arrange your hand into melds: runs (3+ in sequence, same suit) and sets (3–4 of a kind).",
+      "Cards not in a meld are 'deadwood'. Face cards = 10, aces = 1, pips = face value.",
+      "'Knock' by discarding face down when your deadwood totals 10 or less. Lay down your melds.",
+      "'Gin' is knocking with zero deadwood for a bonus.",
+    ],
+    howToWin:
+      "After a knock, the knocker scores the difference in deadwood. Opponent may 'lay off' matching cards onto the knocker's melds first. First to the target total wins the match.",
+    variants: [
+      {
+        name: "Undercut",
+        description:
+          "If the non-knocker's deadwood is equal or lower, they score the difference plus a 25-point undercut bonus.",
+      },
+      {
+        name: "Oklahoma Gin",
+        description:
+          "The first upcard's value sets the maximum deadwood you may knock with that hand.",
+      },
+    ],
+    scoring: {
+      scoringType: "first-to-target",
+      scoringNotes:
+        "Per hand: knocker scores deadwood difference; Gin = difference + 25 bonus; undercut = difference + 25 to the opponent. Add 25 per line and 100 for the game when first to reach the target.",
+      target: 100,
+    },
+  },
+  {
+    id: "golf",
+    name: "Golf (6-card)",
+    hook: "Lowest hand wins, like golf. Nine deals, low score takes it.",
+    tags: { difficulty: "medium", length: "medium", vibe: "strategic" },
+    players: "2+",
+    setup: [
+      "Deal 6 cards to each player, arranged face down in a 2×3 grid.",
+      "Place the rest face down as the stock; flip the top card to start the discard pile.",
+      "Each player secretly peeks at two of their six cards to start.",
+    ],
+    howToPlay: [
+      "On your turn, draw from the stock or take the top discard.",
+      "Swap the drawn card for any of your six (placing the replaced card on the discard), or discard the drawn stock card.",
+      "You're trying to make your grid total as LOW as possible.",
+      "Vertical pairs of equal rank cancel to zero.",
+      "When a player thinks their layout is lowest, they knock; everyone else gets one final turn, then all cards are revealed.",
+    ],
+    howToWin:
+      "Lowest total over the agreed number of deals (a full 'round of golf' is 9 deals) wins.",
+    variants: [
+      {
+        name: "Kings are zero",
+        description:
+          "Kings count as 0 instead of a high value, changing strategy.",
+      },
+      {
+        name: "4-card or 9-card Golf",
+        description: "Deal a 2×2 or 3×3 grid for a shorter or longer game.",
+      },
+    ],
+    scoring: {
+      scoringType: "low-score",
+      scoringNotes:
+        "Card values: ace=1, 2–10 face value, jack/queen=10, king=0, joker (if used)=-2. Matched vertical pairs cancel to 0. Add each deal to a running total; lowest total after all deals (default 9) wins.",
+      target: 9,
+    },
+  },
+  {
+    id: "casino",
+    name: "Casino",
+    hook: "Capture and build cards from the table. A thinky fishing game.",
+    tags: { difficulty: "medium", length: "medium", vibe: "strategic" },
+    players: "2+",
+    setup: [
+      "Deal 2 cards to each player and 4 cards face up to the table; keep 2 in hand.",
+      "Deal the remaining stock in later rounds of 4 as hands empty.",
+    ],
+    howToPlay: [
+      "On your turn, play one card from hand to capture table cards, make a build, trail, or pair.",
+      "Capture by matching a table card's rank, or by summing number cards to your played card (aces = 1).",
+      "Build: combine table cards to a value you can later capture with a card in hand.",
+      "Trail: if you can't or don't want to capture, lay a card face up on the table.",
+      "Face cards capture only by exact rank match, not by summing.",
+    ],
+    howToWin:
+      "When all cards are played, score captured cards. Highest score reaching the target (usually 21) over successive deals wins.",
+    variants: [
+      {
+        name: "Royal Casino",
+        description:
+          "Face cards get numeric values (J=11, Q=12, K=13, A=1 or 14) and can be captured by building.",
+      },
+      {
+        name: "Spade Casino",
+        description:
+          "Score 1 point per spade instead of just the majority — sweeps get emphasised.",
+      },
+    ],
+    scoring: {
+      scoringType: "first-to-target",
+      scoringNotes:
+        "Per deal: most cards = 3, most spades = 1, big casino (10♦) = 2, little casino (2♠) = 1, each ace = 1, each sweep (clearing the table) = 1. First to 21 over multiple deals wins.",
+      target: 21,
+    },
+  },
+  {
+    id: "beggar-my-neighbour",
+    name: "Beggar-My-Neighbour",
+    hook: "Face-card duels decide the pile. No decisions, all fate.",
+    tags: { difficulty: "easy", length: "long", vibe: "luck" },
+    players: "2",
+    setup: [
+      "Deal the whole deck evenly, 26 cards each, face down. Don't look.",
+    ],
+    howToPlay: [
+      "Take turns playing your top card into a central pile.",
+      "If everyone plays a number card, play just continues.",
+      "When someone plays a face card or ace, the opponent must 'pay': 4 cards for an ace, 3 for a king, 2 for a queen, 1 for a jack.",
+      "If a payment card is itself a face/ace, payment stops and the debt flips to the other player.",
+      "When a payment ends with only number cards, the player who played the last face card takes the whole pile.",
+    ],
+    howToWin: "Collect all 52 cards. The player who runs out of cards loses.",
+    variants: [
+      {
+        name: "Add slaps",
+        description:
+          "Allow slapping doubles or sandwiches (as in Egyptian Rat Screw) to add skill and speed.",
+      },
+      {
+        name: "Three-player",
+        description:
+          "Deal to three and pay the player to your left; last with cards wins.",
+      },
+    ],
+    scoring: {
+      scoringType: "single-winner",
+      scoringNotes:
+        "No points — whoever ends up with all the cards wins. Tap the winner.",
+    },
+  },
+]
+
+export default cardGames

--- a/src/pages/cards.astro
+++ b/src/pages/cards.astro
@@ -1,0 +1,22 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro"
+import CardGames from "../components/CardGames.jsx"
+---
+
+<BaseLayout title="Card Games - Brendan Reed">
+  <div class="m-auto flex max-w-2xl flex-col items-start pb-16">
+    <h1
+      class="mt-6 text-3xl font-bold text-gray-900 md:mt-10 md:text-4xl dark:text-white"
+    >
+      Card Games
+    </h1>
+    <p class="mt-2 text-lg text-gray-900 dark:text-white">
+      A pocket library of easy two-player card games — one deck, no internet.
+      Rules, a scorekeeper, and a Brendan-vs-Scott leaderboard.
+    </p>
+
+    <div class="mt-8 w-full">
+      <CardGames client:only="react" />
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
New **`/cards`** page — a pocket library of easy two-player card games to reference on vacation with a single deck. Offline-first, mobile-first, no backend.

## What's here
- **Library of 10 games** (one standard 52-card deck, 2 players): Go Fish, Crazy 8s, War, Speed (Spit), Egyptian Rat Screw, Snap, Gin Rummy, Golf (6-card), Casino, Beggar-My-Neighbour. Each with setup, how to play, how to win, variants, and scoring — collapsible for fast mobile scanning.
- **Scorekeeper** matched to each game's scoring type: ±steppers with running totals + auto-win detection for target games (Gin/Crazy 8s→100, Casino→21), low-score handling for Golf, and simple "X won" buttons for single-winner games (War, Snap, ERS, Speed, Beggar).
- **Leaderboard** (Brendan vs Scott, names editable): total wins per player, games played, and per-game breakdown. Reset control with confirm.

## Design priorities
- **Bad-network resilient:** zero network calls after load. Everything is client-side.
- **Offline persistence:** `localStorage` (`cards-tracker-v1`), hydrate-on-mount / persist-on-change, all reads/writes + `JSON.parse` guarded by try/catch.
- **Mobile-first:** large tap targets, no horizontal scroll, `max-w-2xl`, Tailwind v4 + dark mode consistent with the site.
- Mirrors the site's existing island + localStorage pattern (headsup / portfolio conventions, since honeymoon isn't on `main` yet).

## Files
- `src/data/cardGames.ts` — typed game library (419 lines)
- `src/components/CardGames.jsx` — React island: browser + scorekeeper + leaderboard (591 lines)
- `src/pages/cards.astro` — BaseLayout wrapper (`client:only="react"`)

Unlisted (not in main nav), matching `/honeymoon` and `/headsup`. Reach it at **`/cards`**.

## Verification
- `npm run build` passes clean; `/cards` prerenders to static HTML.
- No `lint` script in repo; ran `prettier --write` to match style.
- Spot-checked: no `fetch`/network, guarded storage, builds green.

**Check the Netlify deploy preview once it's up** — open `/cards`, browse a couple games, run a scoring session, confirm the leaderboard persists across a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)